### PR TITLE
Mark text input as not autofillable

### DIFF
--- a/app/src/main/res/layout/fragment_add_dialog.xml
+++ b/app/src/main/res/layout/fragment_add_dialog.xml
@@ -26,6 +26,7 @@
             android:id="@+id/add_dialog_topic_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" android:hint="@string/add_dialog_topic_name_hint"
+            android:importantForAutofill="no"
             android:maxLines="1" android:inputType="text" android:maxLength="64"/>
     <CheckBox
             android:text="@string/add_dialog_use_another_server"


### PR DESCRIPTION
This PR fixes a bug I've encountered on my device, a Chromebook Duet tablet. When the device is in tablet view, without the physical keyboard attached, tapping into this "Topic name" text field seems to trip the autofill heuristic, making Android think this text field is a password input, so it pops up the user's password manager to show a prompt. This results in the user being blocked from typing into the text field using the onscreen keyboard:

<img width="250" src="https://user-images.githubusercontent.com/7883508/148163059-ff6796bb-e14c-4ed3-ba3b-a2927512dfe8.png" />

(Screenshot taken in desktop mode, with the physical keyboard attached, because I haven't been able to figure out a way to take screenshots in tablet mode)

Since this textbox is not a password, and also not any of [these field types](https://developer.android.com/guide/topics/text/autofill-optimize) (username, credit card, address, etc.), I figure it should be safe to block autofill for this field.