### PR TITLE
Add support for android 12

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,8 @@
         <!-- Main activity -->
         <activity
                 android:name=".ui.MainActivity"
-                android:label="@string/app_name">
+                android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 
@@ -62,7 +63,8 @@
         <!-- Subscriber service restart on reboot -->
         <receiver
                 android:name=".service.SubscriberService$BootStartReceiver"
-                android:enabled="true">
+                android:enabled="true"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
             </intent-filter>

--- a/app/src/main/java/io/heckel/ntfy/service/SubscriberService.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/SubscriberService.kt
@@ -268,7 +268,7 @@ class SubscriberService : Service() {
 
     private fun createNotification(title: String, text: String): Notification {
         val pendingIntent: PendingIntent = Intent(this, MainActivity::class.java).let { notificationIntent ->
-            PendingIntent.getActivity(this, 0, notificationIntent, 0)
+            PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE)
         }
         return NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification_instant)


### PR DESCRIPTION
The app crashes upon subscribing on a topic on android 12, without these additions, because of the new android APIs.