### PR TITLE
Don't add header 'Connection: close' for keep-alive JSON

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/msg/ApiService.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/ApiService.kt
@@ -116,7 +116,9 @@ class ApiService {
         val sinceVal = if (since == 0L) "all" else since.toString()
         val url = topicUrlJson(baseUrl, topics, sinceVal)
         Log.d(TAG, "Opening subscription connection to $url")
-        val request = requestBuilder(url, user).build()
+        val request = requestBuilder(url, user)
+                .addHeader("Connection", "keep-alive")
+                .build()
         val call = subscriberClient.newCall(request)
         call.enqueue(object : Callback {
             override fun onResponse(call: Call, response: Response) {


### PR DESCRIPTION
The `/json?poll=1` request is kept alive for receiving `application/x-ndjson` as a stream,  but the [`Connection` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection) actually provided is `connection: close`,  which is counter-intuitive to that request.

This shouldn't change behaviour for https://ntfy.sh but it can be helpful when using reverse proxies or other implementations.

---

I have not tested this change @binwiederhier ,  but I thought it better to propose the change than open an issue.
Happy for you to say otherwise.