### PR TITLE
Avoid printing binary in logs

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/up/Distributor.kt
+++ b/app/src/main/java/io/heckel/ntfy/up/Distributor.kt
@@ -10,7 +10,7 @@ import io.heckel.ntfy.util.Log
  */
 class Distributor(val context: Context) {
     fun sendMessage(app: String, connectorToken: String, message: ByteArray) {
-        Log.d(TAG, "Sending MESSAGE to $app (token=$connectorToken): ${String(message)} (${message.size} bytes)}")
+        Log.d(TAG, "Sending MESSAGE to $app (token=$connectorToken): ${message.size} bytes")
         val broadcastIntent = Intent()
         broadcastIntent.`package` = app
         broadcastIntent.action = ACTION_MESSAGE


### PR DESCRIPTION
The ByteArray may contain arbitrary bytes. Printing it to the logs results in garbage and terminal emulators will try to interpret escape codes.