### PR TITLE
Disable tasks for processing google services for variants which do not use them

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,12 @@ android {
     }
 }
 
+android.applicationVariants.all { variant ->
+    def shouldProcessGoogleServices = variant.flavorName == "play"
+    def googleTask = tasks.findByName("process${variant.name.capitalize()}GoogleServices")
+    googleTask.enabled = shouldProcessGoogleServices
+}
+
 dependencies {
     // AndroidX, The Basics
     implementation "androidx.appcompat:appcompat:1.4.2"


### PR DESCRIPTION
Application currently cannot be built if you do not have a google-services.json file, even the fdroid flavor which doesnt use google services. 
This PR disables the process GoogleServices gradle tasks which fail for all variants which aren't a part of the play flavor, e.g. the fdroid flavor.