### PR TITLE
WIP: launch activity using broadcast intent

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/backup/Backuper.kt
+++ b/app/src/main/java/io/heckel/ntfy/backup/Backuper.kt
@@ -129,6 +129,8 @@ class Backuper(val context: Context) {
                             body = a.body,
                             intent = a.intent,
                             extras = a.extras,
+                            intent_class = a.intent_class,
+                            intent_package = a.intent_package,
                             progress = a.progress,
                             error = a.error
                         )
@@ -256,6 +258,8 @@ class Backuper(val context: Context) {
                         body = a.body,
                         intent = a.intent,
                         extras = a.extras,
+                        intent_class = a.intent_class,
+                        intent_package = a.intent_package,
                         progress = a.progress,
                         error = a.error
                     )
@@ -383,6 +387,8 @@ data class Action(
     val body: String?, // used in "http" action
     val intent: String?, // used in "broadcast" action
     val extras: Map<String,String>?, // used in "broadcast" action
+    val intent_class: String?, // used in "broadcast" action
+    val intent_package: String?, // used in "broadcast" action
     val progress: Int?, // used to indicate progress in popup
     val error: String? // used to indicate errors in popup
 )

--- a/app/src/main/java/io/heckel/ntfy/db/Database.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Database.kt
@@ -113,6 +113,8 @@ data class Action(
     @ColumnInfo(name = "body") val body: String?, // used in "http" action
     @ColumnInfo(name = "intent") val intent: String?, // used in "broadcast" action
     @ColumnInfo(name = "extras") val extras: Map<String,String>?, // used in "broadcast" action
+    @ColumnInfo(name = "intent_class") val intent_class: String?, // used in "broadcast" action
+    @ColumnInfo(name = "intent_package") val intent_package: String?, // used in "broadcast" action
     @ColumnInfo(name = "progress") val progress: Int?, // used to indicate progress in popup
     @ColumnInfo(name = "error") val error: String?, // used to indicate errors in popup
 )

--- a/app/src/main/java/io/heckel/ntfy/msg/BroadcastService.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/BroadcastService.kt
@@ -47,10 +47,24 @@ class BroadcastService(private val ctx: Context) {
     fun sendUserAction(action: Action) {
         val intent = Intent()
         intent.action = action.intent ?: USER_ACTION_ACTION
+        if (action.intent_class != null && action.intent_package != null) {
+            intent.setClassName(action.intent_package, action.intent_class)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+            Log.d(
+                TAG,
+                "Sending user action intent to start activity: ${intent.action} to ${action.intent_package}:${action.intent_class} with extras ${intent.extras}"
+            )
+            ctx.startActivity(intent)
+            return
+        }
         action.extras?.forEach { (key, value) ->
             intent.putExtra(key, value)
         }
-        Log.d(TAG, "Sending user action intent broadcast: ${intent.action} with extras ${intent.extras}")
+        Log.d(
+            TAG,
+            "Sending user action intent broadcast: ${intent.action} with extras ${intent.extras}"
+        )
         ctx.sendBroadcast(intent)
     }
 

--- a/app/src/main/java/io/heckel/ntfy/msg/Message.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/Message.kt
@@ -42,6 +42,8 @@ data class MessageAction(
     val body: String?, // used in "http" action
     val intent: String?, // used in "broadcast" action
     val extras: Map<String,String>?, // used in "broadcast" action
+    val intent_class: String?, // used in "broadcast" action
+    val intent_package: String?, // used in "broadcast" action
 )
 
 const val MESSAGE_ENCODING_BASE64 = "base64"

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
@@ -45,6 +45,8 @@ class NotificationParser {
                     body = a.body,
                     intent = a.intent,
                     extras = a.extras,
+                    intent_class = a.intent_class,
+                    intent_package = a.intent_package,
                     progress = null,
                     error = null
                 )
@@ -89,6 +91,8 @@ class NotificationParser {
                 body = a.body,
                 intent = a.intent,
                 extras = a.extras,
+                intent_class = a.intent_class,
+                intent_package = a.intent_package,
                 progress = null,
                 error = null
             )


### PR DESCRIPTION
I don't think I'm going to finish this. Apparently when you use the `android.intent.action.MAIN` intent, you have to use `ctx.startActivity` instead of `ctx.sendBroadcast`. (See [https://developer.android.com/reference/android/content/Intent#standard-activity-actions](https://developer.android.com/reference/android/content/Intent#standard-activity-actions))

So to do it "right", I think we'd need to compare `action.intent` to everything in that list of standard activity actions. If it's in the list, use `ctx.startActivity`. If it's not in the list, use `ctx.sendBroadcast`. But at that point, this becomes a much bigger PR and it has only been requested once so far.

I'll just leave this code here in case we decide to pick it up again in the future.