### PR TITLE
Unify copy-to-clipboard in Utils

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/ui/DetailActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/DetailActivity.kt
@@ -460,12 +460,7 @@ class DetailActivity : AppCompatActivity(), ActionMode.Callback, NotificationFra
         Log.d(TAG, "Copying topic URL $url to clipboard ")
 
         runOnUiThread {
-            val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-            val clip = ClipData.newPlainText("topic address", url)
-            clipboard.setPrimaryClip(clip)
-            Toast
-                .makeText(this, getString(R.string.detail_copied_to_clipboard_message), Toast.LENGTH_LONG)
-                .show()
+            copyToClipboard(this, "topic address", url)
         }
     }
 
@@ -639,13 +634,9 @@ class DetailActivity : AppCompatActivity(), ActionMode.Callback, NotificationFra
                 }
             }
         } else {
-            copyToClipboard(notification)
-        }
-    }
-
-    private fun copyToClipboard(notification: Notification) {
-        runOnUiThread {
-            copyToClipboard(this, notification)
+            runOnUiThread {
+                copyToClipboard(this, "notification", decodeMessage(notification))
+            }
         }
     }
 
@@ -702,12 +693,7 @@ class DetailActivity : AppCompatActivity(), ActionMode.Callback, NotificationFra
                 }.orEmpty()
             }
             runOnUiThread {
-                val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                val clip = ClipData.newPlainText("notifications", content)
-                clipboard.setPrimaryClip(clip)
-                Toast
-                    .makeText(this@DetailActivity, getString(R.string.detail_copied_to_clipboard_message), Toast.LENGTH_LONG)
-                    .show()
+                copyToClipboard(this@DetailActivity, "notifications", content)
                 finishActionMode()
             }
         }

--- a/app/src/main/java/io/heckel/ntfy/ui/DetailAdapter.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/DetailAdapter.kt
@@ -281,12 +281,14 @@ class DetailAdapter(private val activity: Activity, private val lifecycleScope: 
                 openItem.setOnMenuItemClickListener { openFile(context, attachment) }
                 saveFileItem.setOnMenuItemClickListener { saveFile(context, attachment) }
                 deleteItem.setOnMenuItemClickListener { deleteFile(context, notification, attachment) }
-                copyUrlItem.setOnMenuItemClickListener { copyUrl(context, attachment) }
+                copyUrlItem.setOnMenuItemClickListener { copyToClipboard(context, "attachment url", attachment.url); true }
                 downloadItem.setOnMenuItemClickListener { downloadFile(context, notification) }
                 cancelItem.setOnMenuItemClickListener { cancelDownload(context, notification) }
             }
             if (hasClickLink) {
-                copyContentsItem.setOnMenuItemClickListener { copyContents(context, notification) }
+                copyContentsItem.setOnMenuItemClickListener {
+                    copyToClipboard(context, "notification", decodeMessage(notification)); true
+                }
             }
             openItem.isVisible = hasAttachment && attachmentExists
             downloadItem.isVisible = hasAttachment && !attachmentExists && !expired && !inProgress
@@ -477,21 +479,6 @@ class DetailAdapter(private val activity: Activity, private val lifecycleScope: 
 
         private fun cancelDownload(context: Context, notification: Notification): Boolean {
             DownloadManager.cancel(context, notification.id)
-            return true
-        }
-
-        private fun copyUrl(context: Context, attachment: Attachment): Boolean {
-            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-            val clip = ClipData.newPlainText("attachment url", attachment.url)
-            clipboard.setPrimaryClip(clip)
-            Toast
-                .makeText(context, context.getString(R.string.detail_item_menu_copy_url_copied), Toast.LENGTH_LONG)
-                .show()
-            return true
-        }
-
-        private fun copyContents(context: Context, notification: Notification): Boolean {
-            copyToClipboard(context, notification)
             return true
         }
 

--- a/app/src/main/java/io/heckel/ntfy/ui/DetailSettingsActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/DetailSettingsActivity.kt
@@ -412,12 +412,7 @@ class DetailSettingsActivity : AppCompatActivity() {
             topicUrlPref?.summary = topicUrl
             topicUrlPref?.onPreferenceClickListener = OnPreferenceClickListener {
                 val context = context ?: return@OnPreferenceClickListener false
-                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                val clip = ClipData.newPlainText("topic url", topicUrl)
-                clipboard.setPrimaryClip(clip)
-                Toast
-                        .makeText(context, getString(R.string.detail_settings_about_topic_url_copied_to_clipboard_message), Toast.LENGTH_LONG)
-                        .show()
+                copyToClipboard(context, "topic url", topicUrl)
                 true
             }
         }

--- a/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
@@ -552,12 +552,7 @@ class SettingsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPrefere
             versionPref?.summary = version
             versionPref?.onPreferenceClickListener = OnPreferenceClickListener {
                 val context = context ?: return@OnPreferenceClickListener false
-                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                val clip = ClipData.newPlainText("ntfy version", version)
-                clipboard.setPrimaryClip(clip)
-                Toast
-                    .makeText(context, getString(R.string.settings_about_version_copied_to_clipboard_message), Toast.LENGTH_LONG)
-                    .show()
+                copyToClipboard(context, "ntfy version", version)
                 true
             }
         }

--- a/app/src/main/java/io/heckel/ntfy/util/Util.kt
+++ b/app/src/main/java/io/heckel/ntfy/util/Util.kt
@@ -486,7 +486,7 @@ fun copyToClipboard(context: Context, label: String, message: String) {
     val clip = ClipData.newPlainText(label, message)
     clipboard.setPrimaryClip(clip)
     if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
-        val copied = context.getString(R.string.detail_copied_to_clipboard_message)
+        val copied = context.getString(R.string.common_copied_to_clipboard)
         Toast.makeText(context, copied, Toast.LENGTH_LONG).show()
     }
 }

--- a/app/src/main/java/io/heckel/ntfy/util/Util.kt
+++ b/app/src/main/java/io/heckel/ntfy/util/Util.kt
@@ -481,14 +481,14 @@ fun ensureSafeNewFile(dir: File, name: String): File {
     throw Exception("Cannot find safe file")
 }
 
-fun copyToClipboard(context: Context, notification: Notification) {
-    val message = decodeMessage(notification)
+fun copyToClipboard(context: Context, label: String, message: String) {
     val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-    val clip = ClipData.newPlainText("notification message", message)
+    val clip = ClipData.newPlainText(label, message)
     clipboard.setPrimaryClip(clip)
-    Toast
-        .makeText(context, context.getString(R.string.detail_copied_to_clipboard_message), Toast.LENGTH_LONG)
-        .show()
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+        val copied = context.getString(R.string.detail_copied_to_clipboard_message)
+        Toast.makeText(context, copied, Toast.LENGTH_LONG).show()
+    }
 }
 
 fun String.sha256(): String {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -22,11 +22,10 @@
     <string name="detail_item_menu_cancel">إلغاء التنزيل</string>
     <string name="detail_item_menu_save_file">حفظ الملف</string>
     <string name="detail_item_menu_copy_url">إنسخ الرابط</string>
-    <string name="detail_item_menu_copy_contents_copied">تم نسخ الإشعار إلى الحافظة</string>
     <string name="user_dialog_button_save">حفظ</string>
     <string name="add_dialog_base_urls_dropdown_choose">اختر عنوان URL للخدمة</string>
     <string name="add_dialog_login_title">تسجيل الدخول مطلوب</string>
-    <string name="detail_copied_to_clipboard_message">تم نسخه إلى الحافظة</string>
+    <string name="common_copied_to_clipboard">تم نسخه إلى الحافظة</string>
     <string name="detail_instant_delivery_enabled">التسليم الفوري مُفعَّل</string>
     <string name="channel_subscriber_notification_instant_text">مشترِك في الإستلام الفوري للمواضيع</string>
     <string name="add_dialog_login_username_hint">إسم المستخدم</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -111,7 +111,7 @@
     <string name="detail_test_message_error">Грешка при изпращане: %1$s</string>
     <string name="detail_test_message_error_unauthorized_anon">Грешка при изпращане: Анонимното публикуване не е разрешено.</string>
     <string name="detail_test_message_error_too_large">Грешка при изпращане: Прикаченият файл е твърде голям.</string>
-    <string name="detail_copied_to_clipboard_message">Копирано в междинната памет</string>
+    <string name="common_copied_to_clipboard">Копирано в междинната памет</string>
     <string name="detail_item_tags">Етикети: %1$s</string>
     <string name="detail_item_menu_cancel">Отказ от изтегляне</string>
     <string name="detail_instant_delivery_enabled">Незабавното доставяне включено</string>
@@ -210,14 +210,11 @@
     <string name="user_dialog_description_edit">Можете да променяте избрания потребител или да го премахнете.</string>
     <string name="settings_about_version_title">Издание</string>
     <string name="settings_about_header">Относно</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Копирано в междинната памет</string>
     <string name="user_dialog_base_url_hint">Адрес на услугата</string>
     <string name="detail_item_cannot_open">Прикаченият файл не може да бъде отворен: %1$s</string>
     <string name="detail_item_snack_deleted">Известието е премахнато</string>
     <string name="detail_item_snack_undo">Отменяне</string>
     <string name="detail_item_menu_copy_url">Копиране на адреса</string>
-    <string name="detail_item_menu_copy_contents_copied">Известията са копирани в междинната памет</string>
-    <string name="detail_item_menu_copy_url_copied">Адресът е копиран в междинната памет</string>
     <string name="detail_item_menu_open">Отваряне</string>
     <string name="detail_item_menu_delete">Премахване</string>
     <string name="detail_item_menu_download">Изтегляне</string>
@@ -326,7 +323,6 @@
     <string name="detail_settings_appearance_display_name_message">Задайте име на абонамента. За да върнете името по подразбиране (%1$s) оставете празно.</string>
     <string name="detail_settings_about_header">Относно</string>
     <string name="detail_settings_about_topic_url_title">Адрес на темата</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Копирано в междинната памет</string>
     <string name="main_menu_donate_title">Даряване 💸</string>
     <string name="detail_item_cannot_open_apk">Ntfy не може да инсталира получени приложения. Вместо това изтеглете чрез браузъра. За подробности вижте дефект №531.</string>
     <string name="channel_notifications_group_default_name">Подразбирани</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -70,7 +70,7 @@
     <string name="detail_test_message_error_unauthorized_anon">Nelze odeslat zprávu: Anonymní publikování není povoleno.</string>
     <string name="detail_test_message_error_unauthorized_user">Nelze odeslat zprávu: Uživatel \"%1$s\" není autorizován.</string>
     <string name="detail_test_message_error_too_large">Nelze odeslat zprávu: Příloha je příliš velká.</string>
-    <string name="detail_copied_to_clipboard_message">Zkopírováno do schránky</string>
+    <string name="common_copied_to_clipboard">Zkopírováno do schránky</string>
     <string name="detail_instant_delivery_enabled">Okamžité doručení zapnuto</string>
     <string name="detail_instant_delivery_disabled">Okamžité doručení vypnuto</string>
     <string name="detail_deep_link_subscribed_toast_message">Přihlášeno k odběru tématu %1$s</string>
@@ -83,7 +83,6 @@
     <string name="detail_item_menu_save_file">Uložit soubor</string>
     <string name="detail_item_menu_copy_url">Zkopírovat URL</string>
     <string name="detail_item_menu_copy_contents">Kopírovat oznámení</string>
-    <string name="detail_item_menu_copy_contents_copied">Oznámení zkopírováno do schránky</string>
     <string name="detail_item_saved_successfully">Uloženo jako \"%1$s\" do složky \"Stažené\"</string>
     <string name="detail_item_cannot_open">Nelze otevřít přílohu: %1$s</string>
     <string name="detail_item_cannot_open_not_found">Nelze otevřít přílohu: Soubor mohl být smazán nebo jej nemůže otevřít žádná nainstalovaná aplikace.</string>
@@ -218,7 +217,6 @@
     <string name="settings_about_header">O programu</string>
     <string name="settings_about_version_title">Verze</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Zkopírováno do schránky</string>
     <string name="user_dialog_title_add">Přidat uživatele</string>
     <string name="user_dialog_description_edit">Uživatelské jméno a heslo vybraného uživatele můžete upravit nebo odstranit.</string>
     <string name="user_dialog_base_url_hint">URL služby</string>
@@ -243,7 +241,6 @@
     <string name="add_dialog_use_another_server">Použít jiný server</string>
     <string name="add_dialog_login_new_user">Nový uživatel</string>
     <string name="detail_clear_dialog_cancel">Zrušit</string>
-    <string name="detail_item_menu_copy_url_copied">URL zkopírováno do schránky</string>
     <string name="detail_item_download_info_download_failed_expired">stažení se nezdařilo, platnost odkazu vypršela</string>
     <string name="detail_item_cannot_download">Nelze otevřít ani stáhnout přílohu. Platnost odkazu vypršela a žádný místní soubor nebyl nalezen.</string>
     <string name="detail_item_download_info_not_downloaded_expired">nebylo staženo, platnost odkazu vypršela</string>
@@ -322,7 +319,6 @@
     <string name="detail_settings_appearance_display_name_default_summary">%1$s (výchozí)</string>
     <string name="detail_settings_about_header">O aplikaci</string>
     <string name="detail_settings_about_topic_url_title">URL tématu</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Zkopírováno do schránky</string>
     <string name="add_dialog_base_urls_dropdown_clear">Vymazat URL služby</string>
     <string name="main_banner_websocket_button_enable_now">Povolit nyní</string>
     <string name="main_banner_websocket_text">WebSockets jsou doporučenou metodou připojení k vašemu serveru, která může zlepšit zvýšit výdrž baterie, ale může vyžadovat <a href="https://ntfy.sh/docs/config/#nginxapache2caddy">další konfiguraci v proxy serveru</a>. Metodu připojení lze přepnout v Nastavení.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -73,7 +73,7 @@
     <string name="detail_test_message_error">Nachricht kann nicht gesendet werden: %1$s</string>
     <string name="detail_test_message_error_unauthorized_user">Nachricht kann nicht gesendet werden: Benutzer \"%1$s\" hat keine Berechtigung.</string>
     <string name="detail_test_message_error_too_large">Nachricht kann nicht gesendet werden: Anhang zu groß.</string>
-    <string name="detail_copied_to_clipboard_message">In Zwischenablage kopiert</string>
+    <string name="common_copied_to_clipboard">In Zwischenablage kopiert</string>
     <string name="detail_instant_delivery_disabled">Sofortnachrichten deaktiviert</string>
     <string name="detail_item_tags">Tags: %1$s</string>
     <string name="detail_item_snack_deleted">Benachrichtigung gelöscht</string>
@@ -83,9 +83,7 @@
     <string name="detail_item_menu_download">Datei herunterladen</string>
     <string name="detail_item_menu_cancel">Herunterladen abbrechen</string>
     <string name="detail_item_menu_save_file">Datei speichern</string>
-    <string name="detail_item_menu_copy_url_copied">URL in Zwischenablage kopiert</string>
     <string name="detail_item_menu_copy_contents">Benachrichtigung kopieren</string>
-    <string name="detail_item_menu_copy_contents_copied">Benachrichtigung in Zwischenablage kopiert</string>
     <string name="detail_item_saved_successfully">Wurde als \"%1$s\" im Downloads-Ordner gespeichert</string>
     <string name="detail_item_cannot_download">Anhang kann nicht geöffnet oder heruntergeladen werden. Link ist abgelaufen und keine lokale Datei gefunden.</string>
     <string name="detail_item_cannot_open">Anhang kann nicht geöffnet werden: %1$s</string>
@@ -219,7 +217,6 @@
     <string name="settings_about_header">Über</string>
     <string name="settings_about_version_title">Version</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
-    <string name="settings_about_version_copied_to_clipboard_message">In die Zwischenablage kopiert</string>
     <string name="user_dialog_title_add">Benutzer hinzufügen</string>
     <string name="user_dialog_title_edit">Benutzer bearbeiten</string>
     <string name="user_dialog_description_add">Du kannst hier einen Benutzer hinzufügen. Alle Themen auf dem angegebenen Server verwenden dann diesen Benutzer.</string>
@@ -326,7 +323,6 @@
     <string name="detail_settings_appearance_display_name_message">Gib einen eigenen Anzeigenamen für dieses Abo an. Leer lassen für den Standardwert (%1$s).</string>
     <string name="detail_settings_about_topic_url_title">Themen-URL</string>
     <string name="detail_settings_about_header">Über</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">In Zwischenablage kopiert</string>
     <string name="main_menu_donate_title">Spenden 💸</string>
     <string name="detail_item_cannot_open_apk">Apps können nicht mehr installiert werden. Bitte stattdessen über einen Browser herunterladen. Details siehe Issue #531.</string>
     <string name="detail_settings_notifications_dedicated_channels_summary_on">Verwende eigene Einstellungen für dieses Thema</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -60,14 +60,13 @@
     <string name="detail_test_message_error_unauthorized_user">No se pudo enviar el mensaje: El usuario %1$s no está autorizado.</string>
     <string name="detail_test_message_error">No se pudo enviar el mensaje: %1$s</string>
     <string name="detail_test_message_error_too_large">No se pudo enviar el mensaje: El archivo adjunto es demasiado grande.</string>
-    <string name="detail_copied_to_clipboard_message">Copiado al portapapeles</string>
+    <string name="common_copied_to_clipboard">Copiado al portapapeles</string>
     <string name="detail_instant_delivery_enabled">Entrega instantánea habilitada</string>
     <string name="detail_instant_delivery_disabled">Entrega instantánea deshabilitada</string>
     <string name="detail_item_tags">Etiquetas: %1$s</string>
     <string name="detail_item_snack_deleted">Notificación eliminada</string>
     <string name="detail_item_menu_open">Abrir archivo</string>
     <string name="detail_item_menu_download">Descargar archivo</string>
-    <string name="detail_item_menu_copy_contents_copied">Notificación copiada al portapapeles</string>
     <string name="detail_item_saved_successfully">Guardado como %1$s en la carpeta de Descargas</string>
     <string name="detail_item_cannot_open">No se puede abrir el archivo adjunto: %1$s</string>
     <string name="detail_item_cannot_open_url">No se pudo abrir la URL: %1$s</string>
@@ -211,7 +210,6 @@
     <string name="settings_advanced_connection_protocol_entry_ws">WebSockets</string>
     <string name="settings_about_version_title">Versión</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Copiado al portapapeles</string>
     <string name="user_dialog_title_add">Añadir usuario</string>
     <string name="user_dialog_title_edit">Editar usuario</string>
     <string name="user_dialog_description_add">Aquí puede añadir un usuario. Todos los tópicos para el servidor dado utilizarán este usuario.</string>
@@ -225,7 +223,6 @@
     <string name="channel_subscriber_notification_instant_text">Suscrito a tópicos de entrega instantánea</string>
     <string name="main_item_status_unified_push">%1$s (UnifiedPush)</string>
     <string name="add_dialog_use_another_server_description">Introduzca las URL de servicio para suscribirse a los tópicos de otros servidores.</string>
-    <string name="detail_item_menu_copy_url_copied">URL copiada al portapapeles</string>
     <string name="settings_notifications_min_priority_summary_any">Se mostrarán todas las notificaciones</string>
     <string name="settings_notifications_auto_delete_one_month">Después de un mes</string>
     <string name="channel_subscriber_notification_instant_text_three">Suscrito a tres tópicos de entrega instantánea</string>
@@ -322,7 +319,6 @@
     <string name="detail_settings_appearance_display_name_message">Establezca un nombre a mostrar para esta suscripción. Deje en blanco para usar el valor predeterminado (%1$s).</string>
     <string name="detail_settings_about_header">Acerca de</string>
     <string name="detail_settings_about_topic_url_title">URL del tópico</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Copiado a portapapeles</string>
     <string name="add_dialog_base_urls_dropdown_choose">Elija la URL del servicio</string>
     <string name="add_dialog_base_urls_dropdown_clear">Borrar la URL del servicio</string>
     <string name="main_banner_websocket_text">Cambiar a WebSockets es la forma recomendada para conectarse a su servidor, y podría mejorar la vida de la batería, pero puede requerir <a href="https://ntfy.sh/docs/config/#nginxapache2caddy">configuración adicional en su proxy</a>. Esto se puede cambiar en la Configuración.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -34,7 +34,7 @@
     <string name="detail_how_to_intro">Pour envoyer des notifications à ce sujet, veuillez simplement PUT ou POST à l\'URL du sujet.</string>
     <string name="detail_test_title">Test : Vous pouvez mettre un titre si vous le voulez.</string>
     <string name="detail_test_message_error">Incapable d\'envoyer le message : %1$s</string>
-    <string name="detail_copied_to_clipboard_message">Copié dans le presse-papier</string>
+    <string name="common_copied_to_clipboard">Copié dans le presse-papier</string>
     <string name="detail_instant_delivery_disabled">Livraison instantanée inactive</string>
     <string name="detail_item_tags">Étiquettes : %1$s</string>
     <string name="detail_item_snack_undo">Annuler</string>
@@ -108,11 +108,9 @@
     <string name="detail_test_message_error_too_large">Impossible d\'envoyer le message : La pièce jointe est trop lourde.</string>
     <string name="detail_instant_delivery_enabled">Livraison instantanée active</string>
     <string name="detail_item_snack_deleted">Notification supprimée</string>
-    <string name="detail_item_menu_copy_url_copied">L\'URL a été copiée dans le presse-papier</string>
     <string name="detail_item_menu_delete">Supprimer un fichier</string>
     <string name="detail_item_menu_save_file">Sauvegarder le fichier</string>
     <string name="detail_item_menu_copy_contents">Copier la notification</string>
-    <string name="detail_item_menu_copy_contents_copied">La notification a été copiée dans le presse-papier</string>
     <string name="detail_item_saved_successfully">Sauvegardé en tant que \"%1$s\" dans le dossier \"Téléchargements\"</string>
     <string name="detail_item_cannot_download">Incapable d\'ouvrir ou de télécharger la pièce jointe. Le lien est expiré et aucun fichier local n\'a pu être trouvé.</string>
     <string name="detail_item_cannot_open">Incapable d\'ouvrir le pièce jointe : %1$s</string>
@@ -288,7 +286,6 @@
     <string name="settings_advanced_export_logs_copied_url">Journaux téléchargés et URL copiée</string>
     <string name="settings_advanced_connection_protocol_summary_jsonhttp">Utiliser un flux JSON en HTTP pour se connecter au serveur. Cette méthode est éprouvée, mais peut consommer plus de batterie.</string>
     <string name="settings_advanced_connection_protocol_summary_ws">Utiliser des WebSockets pour se connecter au serveur. Il s\'agit de la méthode recommandée, mais peut requérir une configuration supplémentaire de votre proxy.</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Copié dans le presse-papier</string>
     <string name="settings_advanced_record_logs_title">Enregistrer les journaux</string>
     <string name="user_dialog_description_add">Vous pouvez ajouter un utilisateur ici. Tous les sujets du serveur sélectionné utiliseront cet utilisateur.</string>
     <string name="user_dialog_description_edit">Vous pouvez éditer le nom d\'utilisateur et le mot de passe de l\'utilisateur sélectionné, ou le supprimer.</string>
@@ -324,7 +321,6 @@
     <string name="detail_settings_appearance_display_name_title">Nom d\'affichage</string>
     <string name="detail_settings_appearance_display_name_default_summary">%1$s</string>
     <string name="detail_settings_appearance_display_name_message">Mettre un nom d\'affichage personnalisé pour cette souscription. Laisse ce champ vide pour mettre la valeur par défaut (%1$s).</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Copié au Presse-papier</string>
     <string name="detail_settings_about_header">À propos</string>
     <string name="detail_settings_about_topic_url_title">URL du sujet</string>
     <string name="channel_notifications_group_default_name">Défaut</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -97,7 +97,7 @@
     <string name="detail_test_message_error_unauthorized_anon">Non se enviou a mensaxe: Non está permitida a publicación anónima.</string>
     <string name="detail_test_message_error_unauthorized_user">Non se enviou a mensaxe: A usuaria \"%1$s\" non ten autorización.</string>
     <string name="detail_test_message_error_too_large">Non se enviou a mensaxe: O adxunto é demasiado grande.</string>
-    <string name="detail_copied_to_clipboard_message">Copiado ao portapapeis</string>
+    <string name="common_copied_to_clipboard">Copiado ao portapapeis</string>
     <string name="detail_instant_delivery_enabled">Entrega inmediata activada</string>
     <string name="detail_instant_delivery_disabled">Entrega inmediata desactivada</string>
     <string name="detail_deep_link_subscribed_toast_message">Subscrita ao tema %1$s</string>
@@ -110,9 +110,7 @@
     <string name="detail_item_menu_cancel">Cancelar descarga</string>
     <string name="detail_item_menu_save_file">Gardar ficheiro</string>
     <string name="detail_item_menu_copy_url">Copiar URL</string>
-    <string name="detail_item_menu_copy_url_copied">URL copiado ao portapapeis</string>
     <string name="detail_item_menu_copy_contents">Copiar notificación</string>
-    <string name="detail_item_menu_copy_contents_copied">Notificación copiada ao portapapeis</string>
     <string name="detail_item_saved_successfully">Gardado como \"%1$s\" no cartafol \"Descargas\"</string>
     <string name="detail_how_to_intro">Enviar notificacións a este tema, simplemente envía con PUT ou POST ao URL do tema.</string>
     <string name="detail_item_cannot_download">Non se pode abrir ou descargar o adxunto. A ligazón caducou e non se atopa un ficheiro local.</string>
@@ -279,7 +277,6 @@
     <string name="settings_advanced_connection_protocol_entry_jsonhttp">Fluxo JSON sobre HTTP</string>
     <string name="settings_advanced_connection_protocol_entry_ws">WebSockets</string>
     <string name="settings_advanced_connection_protocol_summary_jsonhttp">Usar un fluxo JSON sobre HTTP para conectar co servidor. Este método é robusto, pero podería consumir máis batería.</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Copiado ao portapapeis</string>
     <string name="detail_settings_notifications_instant_title">Entrega inmediata</string>
     <string name="settings_about_header">Acerca de</string>
     <string name="settings_about_version_title">Versión</string>
@@ -292,7 +289,6 @@
     <string name="detail_settings_notifications_open_channels_title">Configurar axustes da notificación</string>
     <string name="detail_settings_appearance_icon_error_saving">Non se gardou a icona: %1$s</string>
     <string name="detail_settings_appearance_display_name_title">Nome mostrado</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Copiado ao portapapeis</string>
     <string name="settings_backup_restore_restore_title">Restablecer desde ficheiro</string>
     <string name="settings_backup_restore_restore_summary">Importar configuración, notificacións e usuarias</string>
     <string name="settings_backup_restore_restore_successful">Restablecemento correcto</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -69,7 +69,6 @@
     <string name="detail_item_snack_deleted">Értesítés törölve</string>
     <string name="detail_item_menu_download">Fájl letöltése</string>
     <string name="detail_test_message_error_unauthorized_user">Nem sikerült az üzenetet elküldeni: A \"%1$s\" felhasználó jogosultságai nem megfelelőek.</string>
-    <string name="detail_item_menu_copy_url_copied">URL a vágólapra másolva</string>
     <string name="detail_item_menu_copy_contents">Értesítés másolása</string>
     <string name="add_dialog_title">Feliratokozás a témára</string>
     <string name="main_banner_websocket_button_enable_now">Engedélyezés most</string>
@@ -79,7 +78,6 @@
     <string name="detail_clear_dialog_message">Töröljük az összes értesítést ebben a témában\?</string>
     <string name="detail_test_message_error_too_large">Nem sikerült az üzenetet elküldeni: A csatolmány túl nagy.</string>
     <string name="detail_deep_link_subscribed_toast_message">Feliratkozva a %1$s témára</string>
-    <string name="detail_item_menu_copy_contents_copied">Értesítés a vágólapra másolva</string>
     <string name="main_banner_battery_button_remind_later">Később</string>
     <string name="main_how_to_link">Részletes leírás elérhető a ntfy.sh oldalon és a dokumentációban.</string>
     <string name="main_banner_battery_text">Az akkumulátor optimalizáció kikapcsolása javasolt az értesítési problémák elkerülésére.</string>
@@ -95,7 +93,7 @@
     <string name="detail_no_notifications_text">Még nem érkezett értesítés ebben a témában.</string>
     <string name="detail_delete_dialog_permanently_delete">Végleges törlés</string>
     <string name="detail_test_message_error_unauthorized_anon">Nem sikerült az üzenetet elküldni: A névtelen publikálás nem engedélyezett.</string>
-    <string name="detail_copied_to_clipboard_message">Vágólapra másolva</string>
+    <string name="common_copied_to_clipboard">Vágólapra másolva</string>
     <string name="detail_instant_delivery_enabled">Azonnali küldés bekapcsolva</string>
     <string name="detail_instant_delivery_disabled">Azonnali küldés kikapcsolva</string>
     <string name="detail_item_menu_open">Fájl megnyitása</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -67,7 +67,7 @@
     <string name="detail_test_message_error">Tidak dapat mengirimkan pesan: %1$s</string>
     <string name="detail_test_message_error_unauthorized_anon">Tidak dapat mengirimkan pesan: Penerbitan anonim tidak diizinkan.</string>
     <string name="detail_test_message_error_too_large">Tidak dapat mengirimkan pesan: Lampiran terlalu besar.</string>
-    <string name="detail_copied_to_clipboard_message">Disalin ke papan klip</string>
+    <string name="common_copied_to_clipboard">Disalin ke papan klip</string>
     <string name="detail_instant_delivery_enabled">Pengiriman instan menyala</string>
     <string name="detail_instant_delivery_disabled">Pengiriman instan mati</string>
     <string name="detail_item_tags">Tanda: %1$s</string>
@@ -79,7 +79,6 @@
     <string name="detail_item_menu_cancel">Batalkan unduhan</string>
     <string name="detail_item_menu_save_file">Simpan file</string>
     <string name="detail_item_menu_copy_url">Salin URL</string>
-    <string name="detail_item_menu_copy_url_copied">URL disalin ke papan klip</string>
     <string name="detail_item_menu_copy_contents">Salin notifikasi</string>
     <string name="detail_item_cannot_open_not_found">Tidak dapat membuka lampiran: File mungkin terhapus, atau tidak ada aplikasi yang terinstal yang dapat membuka file.</string>
     <string name="detail_item_cannot_save">Tidak dapat menyimpan lampiran: %1$s</string>
@@ -209,7 +208,6 @@
     <string name="user_dialog_description_edit">Anda dapat mengubah nama pengguna/kata sandi untuk pengguna yang dipilih, atau hapus pengguna itu.</string>
     <string name="user_dialog_base_url_hint">URL Layanan</string>
     <string name="channel_subscriber_notification_noinstant_text_one">Berlangganan ke satu topik</string>
-    <string name="detail_item_menu_copy_contents_copied">Notifikasi disalin ke papan klip</string>
     <string name="detail_item_cannot_open_url">Tidak dapat membuka URL: %1$s</string>
     <string name="settings_notifications_min_priority_summary_any">Menampilkan semua notifikasi</string>
     <string name="settings_notifications_min_priority_summary_x_or_higher">Tampilkan notifikasi jika prioritas adalah %1$d (%2$s) atau di atas</string>
@@ -290,7 +288,6 @@
     <string name="settings_advanced_header">Tingkat lanjut</string>
     <string name="settings_advanced_broadcast_summary_enabled">Aplikasi dapat menerima notifikasi yang datang sebagai siaran</string>
     <string name="settings_advanced_export_logs_summary">Salin catatan ke papan klip, atau unggah ke nopaste.net (dimiliki oleh penulis ntfy). Nama host dan topik dapat disensor, notifikasi tidak akan disensor.</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Disalin ke papan klip</string>
     <string name="user_dialog_password_hint_add">Kata Sandi</string>
     <string name="user_dialog_button_delete">Hapus pengguna</string>
     <string name="user_dialog_password_hint_edit">Kata Sandi (tidak diubah jika ditinggalkan kosong)</string>
@@ -324,7 +321,6 @@
     <string name="detail_settings_appearance_display_name_title">Nama tampilan</string>
     <string name="detail_settings_appearance_display_name_default_summary">%1$s (bawaan)</string>
     <string name="detail_settings_appearance_display_name_message">Tetapkan sebuah nama tampilan kustom untuk langganan ini. Tinggalkan kosong untuk bawaan (%1$s).</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Disalin ke papan klip</string>
     <string name="detail_settings_about_header">Tentang</string>
     <string name="detail_settings_about_topic_url_title">URL Topik</string>
     <string name="main_menu_donate_title">Donasi 💸</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -63,13 +63,12 @@
     <string name="detail_test_title">Test: Puoi impostare un titolo, se vuoi.</string>
     <string name="detail_test_message_error_unauthorized_anon">Impossibile inviare il messaggio: Pubblicazione anonima non permessa.</string>
     <string name="detail_test_message_error_unauthorized_user">Impossibile inviare il messaggio: L\'utente \"%1$s\" non è autorizzato.</string>
-    <string name="detail_copied_to_clipboard_message">Copiato negli appunti</string>
+    <string name="common_copied_to_clipboard">Copiato negli appunti</string>
     <string name="detail_instant_delivery_enabled">Consegna istantanea ON</string>
     <string name="detail_item_tags">Tags: %1$s</string>
     <string name="detail_test_message_error_too_large">Impossibile inviare il messaggio: L\'allegato è troppo grande.</string>
     <string name="detail_item_snack_deleted">Notifica eliminata</string>
     <string name="detail_item_snack_undo">Annulla</string>
-    <string name="detail_item_menu_copy_contents_copied">Notifica copiata negli appunti</string>
     <string name="detail_item_cannot_download">Impossibile aprire o scaricare l\'allegato. Il link è scaduto e nessun file locale è stato trovato.</string>
     <string name="detail_item_cannot_open">Impossibile aprire l\'allegato: %1$s</string>
     <string name="detail_item_cannot_open_url">Impossibile aprire URL: %1$s</string>
@@ -205,7 +204,6 @@
     <string name="detail_item_menu_save_file">Salva il file</string>
     <string name="detail_item_menu_copy_url">Copia URL</string>
     <string name="detail_menu_copy_url">Copia l\'indirizzo del topic</string>
-    <string name="detail_item_menu_copy_url_copied">URL copiato negli appunti</string>
     <string name="detail_menu_notifications_enabled">Notifiche ON</string>
     <string name="detail_test_message_error">Impossibile inviare il messaggio: %1$s</string>
     <string name="detail_item_menu_cancel">Interrompi il download</string>
@@ -288,7 +286,6 @@
     <string name="settings_advanced_connection_protocol_summary_ws">Usa WebSockets per collegarti al server. Questo è il metodo consigliato, ma potrebbe richiedere una configurazione aggiuntiva del proxy.</string>
     <string name="settings_advanced_connection_protocol_entry_ws">WebSockets</string>
     <string name="user_dialog_title_add">Aggiungi utente</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Copiato negli appunti</string>
     <string name="user_dialog_title_edit">Modifica utente</string>
     <string name="channel_subscriber_notification_title">In attesa di notifiche in ingresso</string>
     <string name="detail_test_message">Questa è una notifica test dall\'app Android ntfy. Ha livello di priorità %1$d. Se ne invii un\'altra, potrebbe avere contenuti differenti.</string>
@@ -323,7 +320,6 @@
     <string name="detail_settings_appearance_display_name_message">Impostare un nome di visualizzazione personalizzato per questa iscrizione. Lasciare vuoto per il nome predefinito (%1$s).</string>
     <string name="detail_settings_about_header">Informazioni</string>
     <string name="detail_settings_about_topic_url_title">URL argomento</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Copiato negli appunti</string>
     <string name="add_dialog_base_urls_dropdown_choose">Scegli il servizio URL</string>
     <string name="add_dialog_base_urls_dropdown_clear">Pulisci il servizio URL</string>
     <string name="main_banner_websocket_button_enable_now">Attiva ora</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -96,7 +96,7 @@
     <string name="share_topic_title">共有する</string>
     <string name="notification_popup_action_open">開く</string>
     <string name="detail_test_message_error_too_large">メッセージを送信できませんでした: 添付サイズが大きすぎます。</string>
-    <string name="detail_copied_to_clipboard_message">クリップボードにコピーしました</string>
+    <string name="common_copied_to_clipboard">クリップボードにコピーしました</string>
     <string name="detail_item_snack_undo">元に戻す</string>
     <string name="detail_item_menu_open">ファイルを開く</string>
     <string name="detail_item_menu_delete">ファイルを削除</string>
@@ -107,9 +107,7 @@
     <string name="detail_instant_delivery_disabled">即時配信オフ</string>
     <string name="detail_item_snack_deleted">通知を削除しました</string>
     <string name="detail_item_menu_download">ファイルをダウンロード</string>
-    <string name="detail_item_menu_copy_url_copied">URLをクリップボードにコピーしました</string>
     <string name="detail_item_menu_copy_contents">通知をコピー</string>
-    <string name="detail_item_menu_copy_contents_copied">通知をクリップボードにコピーしました</string>
     <string name="detail_item_cannot_download">添付ファイルを開くまたはダウンロードできませんでした。リンクが失効しているか、ローカルファイルが見つかりません。</string>
     <string name="detail_item_cannot_delete">添付ファイルを削除できません: %1$s</string>
     <string name="detail_item_download_info_not_downloaded">未ダウンロード</string>
@@ -283,7 +281,6 @@
     <string name="settings_advanced_clear_logs_summary">これまで記録されたログを消去し、再開します</string>
     <string name="settings_advanced_clear_logs_deleted_toast">ログが削除されました</string>
     <string name="settings_advanced_connection_protocol_summary_jsonhttp">サーバーへの接続に JSON stream over HTTP を使用します。このメソッドは様々な場面で使われていますが、バッテリーをより多く消費します。</string>
-    <string name="settings_about_version_copied_to_clipboard_message">クリップボードにコピーしました</string>
     <string name="user_dialog_title_add">ユーザーを追加</string>
     <string name="user_dialog_description_edit">選択されたユーザーのユーザー名/パスワードを変更または削除できます。</string>
     <string name="user_dialog_base_url_hint">サービスURL</string>
@@ -326,7 +323,6 @@
     <string name="main_banner_websocket_button_enable_now">今すぐ有効化</string>
     <string name="detail_settings_about_header">About</string>
     <string name="detail_settings_about_topic_url_title">トピックのURL</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">クリップボードにコピーしました</string>
     <string name="main_menu_donate_title">寄付する💸</string>
     <string name="detail_item_cannot_open_apk">アプリはインストールできなくなりました。代替手段としてブラウザからダウンロードしてください。詳細は issue #531 をご参照ください。</string>
     <string name="settings_notifications_insistent_max_priority_summary_enabled">優先度最高は非表示になるまで通知継続</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -196,7 +196,6 @@
     <string name="detail_how_to_intro">알림을 받으려면 아래 주소로 PUT이나 POST 요청을 보내세요.</string>
     <string name="detail_deep_link_subscribed_toast_message">주제 %1$s 를 구독했습니다</string>
     <string name="detail_item_menu_cancel">다운로드 취소</string>
-    <string name="detail_item_menu_copy_contents_copied">알림이 클립보드로 복사됨</string>
     <string name="detail_item_cannot_save">첨부 파일을 저장할 수 없습니다: %1$s</string>
     <string name="detail_item_cannot_delete">첨부 파일을 삭제할 수 없습니다: %1$s</string>
     <string name="share_content_title">메세지 미리보기</string>
@@ -208,11 +207,9 @@
     <string name="detail_item_menu_download">파일 다운로드</string>
     <string name="detail_item_cannot_download">첨부 파일을 열거나 다운로드할 수 없습니다. 링크가 만료되었으며 로컬 사본을 찾을 수 없습니다.</string>
     <string name="settings_general_users_prefs_user_used_by_one">주제 %1$s에서 사용됨</string>
-    <string name="settings_about_version_copied_to_clipboard_message">클립보드에 복사됨</string>
     <string name="detail_settings_global_setting_title">전역 설정 사용하기</string>
-    <string name="detail_copied_to_clipboard_message">클립보드에 복사됨</string>
+    <string name="common_copied_to_clipboard">클립보드에 복사됨</string>
     <string name="detail_item_menu_open">파일 열기</string>
-    <string name="detail_item_menu_copy_url_copied">URL이 클립보드에 복사됨</string>
     <string name="add_dialog_base_urls_dropdown_choose">서비스 URL 선택</string>
     <string name="detail_how_to_example">예제 (curl 사용):<br/><tt>$ curl -d \\\"Hi\\\" %1$s</tt></string>
     <string name="share_content_file_error">파일 정보를 읽을 수 없습니다: %1$s</string>
@@ -321,7 +318,6 @@
     <string name="user_dialog_title_edit">사용자 편집</string>
     <string name="user_dialog_base_url_hint">서비스 URL</string>
     <string name="user_dialog_password_hint_edit">비밀번호 (변경시에만 입력)</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">클립보드에 복사됨</string>
     <string name="user_dialog_title_add">사용자 추가</string>
     <string name="user_dialog_description_edit">선택한 사용자의 아이디나 비밀번호를 변경하거나 삭제할 수 있습니다.</string>
     <string name="user_dialog_password_hint_add">비밀번호</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -66,7 +66,6 @@
     <string name="detail_item_menu_cancel">Avbryt nedlasting</string>
     <string name="detail_item_menu_save_file">Lagre fil</string>
     <string name="detail_item_menu_copy_url">Kopier nettadresse</string>
-    <string name="detail_item_menu_copy_url_copied">URL kopiert til utklippstavlen</string>
     <string name="detail_item_menu_copy_contents">Kopier merknad</string>
     <string name="detail_item_cannot_download">Kan ikke åpne eller laste ned vedlegg. Lenken utløp og ingen lokal fil ble funnet.</string>
     <string name="detail_item_cannot_open">Kan ikke åpne vedlegg: %1$s</string>
@@ -91,10 +90,9 @@
     <string name="detail_menu_settings">Abonnementsinnstillinger</string>
     <string name="detail_menu_unsubscribe">Opphev abonnement</string>
     <string name="detail_instant_delivery_disabled">Umiddelbar levering avskrudd</string>
-    <string name="detail_item_menu_copy_contents_copied">Varsel kopiert til utklippstavlen</string>
     <string name="detail_test_message_error_unauthorized_user">Kan ikke sende melding: Brukeren \"%1$s\" er ikke autorisert.</string>
     <string name="detail_test_message_error_too_large">Kan ikke sende melding: Vedlegget er for stort.</string>
-    <string name="detail_copied_to_clipboard_message">Kopiert til utklippstavlen</string>
+    <string name="common_copied_to_clipboard">Kopiert til utklippstavlen</string>
     <string name="detail_instant_delivery_enabled">Umiddelbar levering påskrudd</string>
     <string name="detail_action_mode_delete_dialog_permanently_delete">Slett permanent</string>
     <string name="detail_action_mode_delete_dialog_cancel">Avbryt</string>
@@ -196,7 +194,6 @@
     <string name="settings_advanced_clear_logs_deleted_toast">Logger slettet</string>
     <string name="settings_advanced_connection_protocol_summary_jsonhttp">Bruk en JSON-strøm over HTTP for å koble til tjeneren. Dette er en godt utprøvd metode, men kan bruke mer batteri.</string>
     <string name="settings_about_header">Om</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Kopiert til utklippstavlen</string>
     <string name="user_dialog_title_add">Legg til bruker</string>
     <string name="user_dialog_title_edit">Rediger bruker</string>
     <string name="user_dialog_base_url_hint">Tjeneste-URL</string>
@@ -322,7 +319,6 @@
     <string name="detail_settings_appearance_icon_error_saving">Kan ikke lagre ikon: %1$s</string>
     <string name="detail_settings_appearance_display_name_title">Visningsnavn</string>
     <string name="detail_settings_appearance_display_name_default_summary">%1$s (standard)</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Kopier til utklippstavlen</string>
     <string name="detail_settings_appearance_display_name_message">Angi et tilpasset visningsnavn for dette abonnementet. La stå tomt for standard (%1$s).</string>
     <string name="main_menu_donate_title">Doner 💸</string>
     <string name="main_banner_websocket_text">Å bytte til WebSockets er den anbefalte måten å koble til serveren på, og kan forbedre batterilevetiden, men kan kreve <a href="https://ntfy.sh/docs/config/#nginxapache2caddy">ytterligere konfigurasjon i proxy-serveren</a>. Dette kan endres i innstillingene.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -85,7 +85,6 @@
     <string name="settings_advanced_export_logs_error_uploading">Kon logs niet uploaden: %1$s</string>
     <string name="user_dialog_title_add">Gebruiker toevoegen</string>
     <string name="settings_advanced_export_logs_uploading">Log uploaden …</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Gekopieerd naar het klembord</string>
     <string name="detail_menu_notifications_disabled_forever">Meldingen gedempt</string>
     <string name="detail_menu_notifications_disabled_until">Meldingen gedempt tot %1$s</string>
     <string name="detail_menu_test">Testmelding verzenden</string>
@@ -123,9 +122,7 @@
     <string name="settings_general_dark_mode_entry_dark">Donkere modus</string>
     <string name="settings_general_default_base_url_title">Standaardserver</string>
     <string name="settings_general_users_title">Gebruikers beheren</string>
-    <string name="detail_item_menu_copy_url_copied">URL gekopieerd naar klembord</string>
     <string name="detail_item_menu_open">Bestand openen</string>
-    <string name="detail_item_menu_copy_contents_copied">Melding gekopieerd naar klembord</string>
     <string name="detail_item_saved_successfully">Opgeslagen als \"%1$s\" in de \"Downloads\" folder</string>
     <string name="detail_item_menu_save_file">Bestand opslaan</string>
     <string name="detail_item_snack_undo">Ongedaan maken</string>
@@ -212,7 +209,7 @@
     <string name="detail_test_message_error_unauthorized_anon">Kan bericht niet versturen: Anoniem publiceren niet toegestaan.</string>
     <string name="detail_test_message_error_unauthorized_user">Kan bericht niet versturen: De gebruiker \"%1$s\" is niet geautoriseerd.</string>
     <string name="detail_test_message_error_too_large">Kan bericht niet versturen: De bijlage is te groot.</string>
-    <string name="detail_copied_to_clipboard_message">Gekopieerd naar het klembord</string>
+    <string name="common_copied_to_clipboard">Gekopieerd naar het klembord</string>
     <string name="detail_instant_delivery_enabled">Directe levering aan</string>
     <string name="detail_item_tags">Tags: %1$s</string>
     <string name="detail_item_snack_deleted">Notificatie verwijderd</string>
@@ -322,7 +319,6 @@
     <string name="detail_settings_appearance_display_name_message">Zet een schermnaam voor dit abonnement. Laat het veld leeg om de standaard naam te kiezen (%1$s).</string>
     <string name="detail_settings_about_header">Over</string>
     <string name="detail_settings_about_topic_url_title">Onderwerp URL</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Gekopieerd naar klembord</string>
     <string name="add_dialog_base_urls_dropdown_choose">Kies service URL</string>
     <string name="add_dialog_base_urls_dropdown_clear">Service URL verwijderen</string>
     <string name="main_banner_websocket_button_enable_now">Nu inschakelen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -116,7 +116,7 @@
     <string name="detail_test_message_error_unauthorized_anon">Nie można wysłać wiadomości: Anonimowa publikacja nie jest dozwolona.</string>
     <string name="detail_test_message_error_unauthorized_user">Nie można wysłać wiadomości: Użytkownik \"%1$s\" nie ma uprawnień.</string>
     <string name="detail_test_message_error_too_large">Nie można wysłać wiadomości: Załącznik jest zbyt duży.</string>
-    <string name="detail_copied_to_clipboard_message">Skopiowano do schowka</string>
+    <string name="common_copied_to_clipboard">Skopiowano do schowka</string>
     <string name="detail_item_cannot_delete">Nie można usunąć załącznika: %1$s</string>
     <string name="detail_item_download_failed">Nie można pobrać załącznika: %1$s</string>
     <string name="detail_item_download_info_not_downloaded">nie pobrany</string>
@@ -173,7 +173,6 @@
     <string name="detail_settings_global_setting_suffix">przy użyciu ustawienia globalnego</string>
     <string name="detail_settings_about_header">Informacje o</string>
     <string name="detail_settings_about_topic_url_title">Adres URL tematu</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Skopiowano do schowka</string>
     <string name="user_dialog_password_hint_add">Hasło</string>
     <string name="user_dialog_password_hint_edit">Hasło (niezmienione, jeśli pozostawiono puste)</string>
     <string name="user_dialog_button_delete">Usuń użytkownika</string>
@@ -207,9 +206,7 @@
     <string name="detail_item_cannot_save">Nie można zapisać załącznika: %1$s</string>
     <string name="detail_item_menu_open">Otwórz plik</string>
     <string name="detail_item_menu_copy_url">Kopiuj Adres URL</string>
-    <string name="detail_item_menu_copy_url_copied">Adres URL skopiowany do schowka</string>
     <string name="detail_item_menu_copy_contents">Kopiuj powiadomienie</string>
-    <string name="detail_item_menu_copy_contents_copied">Powiadomienie skopiowane do schowka</string>
     <string name="detail_item_saved_successfully">Zapisane jako \"%1$s\" w folderze \"Downloads\"</string>
     <string name="detail_item_cannot_download">Nie można otworzyć lub pobrać załącznika. Link wygasł i nie można było znaleźć lokalnego pliku.</string>
     <string name="detail_item_cannot_open">Nie można otworzyć załącznika: %1$s</string>
@@ -314,7 +311,6 @@
     <string name="settings_advanced_connection_protocol_entry_jsonhttp">Strumień JSON przez HTTP</string>
     <string name="settings_about_version_title">Wersja</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Skopiowano do schowka</string>
     <string name="detail_settings_notifications_instant_summary_on">Powiadomienia są dostarczane natychmiastowo. Wymaga usługi pierwszego planu i zużywa więcej baterii.</string>
     <string name="detail_settings_appearance_header">Wygląd</string>
     <string name="detail_settings_appearance_icon_set_title">Ikona subskrypcji</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -71,9 +71,7 @@
     <string name="detail_item_menu_cancel">Cancelar download</string>
     <string name="detail_item_menu_save_file">Salvar arquivo</string>
     <string name="detail_item_menu_copy_url">Copiar URL</string>
-    <string name="detail_item_menu_copy_url_copied">URL copiada para área de transferência</string>
     <string name="detail_item_menu_copy_contents">Copiar notificação</string>
-    <string name="detail_item_menu_copy_contents_copied">Notificação copiada para área de transferência</string>
     <string name="detail_item_saved_successfully">\"%1$s\" salvo na pasta \"Downloads\"</string>
     <string name="detail_item_cannot_download">Não foi possível abrir ou baixar o anexo. O link expirou e nenhum arquivo local foi encontrado.</string>
     <string name="detail_item_cannot_open_url">Não foi possível abrir a URL: %1$s</string>
@@ -190,7 +188,6 @@
     <string name="settings_about_header">Sobre</string>
     <string name="settings_about_version_title">Versão</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Copiado para a área de transferência</string>
     <string name="user_dialog_title_add">Adicionar usuário</string>
     <string name="user_dialog_title_edit">Editar usuário</string>
     <string name="user_dialog_description_edit">Você pode editar nome de usuário/senha para o usuário selecionado ou apagá-lo.</string>
@@ -228,7 +225,7 @@
     <string name="detail_item_download_info_deleted_expires_x">apagado, link expira em %1$s</string>
     <string name="detail_item_download_info_download_failed_expires_x">download falhou, link expira em %1$s</string>
     <string name="detail_test_message_error_unauthorized_anon">Não foi possível enviar mensagem: Publicação anônima não permitida.</string>
-    <string name="detail_copied_to_clipboard_message">Copiado para área de transferência</string>
+    <string name="common_copied_to_clipboard">Copiado para área de transferência</string>
     <string name="detail_item_tags">Categorias: %1$s</string>
     <string name="detail_item_cannot_open">Não foi possível abrir o anexo: %1$s</string>
     <string name="detail_menu_notifications_enabled">Notificações ativadas</string>
@@ -323,7 +320,6 @@
     <string name="main_banner_websocket_text">Mudar para WebSockets é o modo recomendado de conectar ao seu servidor, e pode melhorar a vida da bateria, mas pode necessitar de <a href="https://ntfy.sh/docs/config/#nginxapache2caddy">configurações adicionais no seu proxy</a>. Isso pode ser habilitado nas Configurações.</string>
     <string name="detail_settings_about_header">Sobre</string>
     <string name="detail_settings_about_topic_url_title">URL do tópico</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Copiado para área de transferência</string>
     <string name="add_dialog_base_urls_dropdown_choose">Escolha o URL do serviço</string>
     <string name="add_dialog_base_urls_dropdown_clear">Limpar o URL do serviço</string>
     <string name="main_banner_websocket_button_enable_now">Habilitar agora</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -72,7 +72,7 @@
     <string name="detail_test_title">Teste: Pode definir um título se quiser.</string>
     <string name="detail_test_message_error">Não foi possível enviar a mensagem: %1$s</string>
     <string name="detail_test_message_error_unauthorized_anon">Não foi possível enviar a mensagem: Publicações anónimas não são permitidas.</string>
-    <string name="detail_copied_to_clipboard_message">Copiado para a área de transferência</string>
+    <string name="common_copied_to_clipboard">Copiado para a área de transferência</string>
     <string name="detail_deep_link_subscribed_toast_message">Tópico \"%1$s\" subscrito</string>
     <string name="detail_item_tags">Etiquetas: %1$s</string>
     <string name="detail_item_snack_deleted">Notificação eliminada</string>
@@ -205,7 +205,6 @@
     <string name="settings_backup_restore_backup_successful">Cópia criada</string>
     <string name="settings_backup_restore_backup_failed">Falha ao criar cópia: %1$s</string>
     <string name="detail_item_saved_successfully">Guardado como \"%1$s\" na pasta \"Downloads\" (\"Transferências\")</string>
-    <string name="detail_item_menu_copy_contents_copied">Notificação copiada para a área de transferência</string>
     <string name="detail_item_cannot_download">Não foi possível abrir ou descarregar o anexo. A ligação expirou e nenhum ficheiro local foi encontrado.</string>
     <string name="detail_item_download_info_not_downloaded_expired">não foi descarregado, a ligação expirou</string>
     <string name="detail_menu_notifications_disabled_until">Notificações silenciadas até %1$s</string>
@@ -242,7 +241,6 @@
     <string name="detail_test_message_error_unauthorized_user">Não foi possível enviar a mensagem: O utilizador \"%1$s\" não está autorizado.</string>
     <string name="detail_instant_delivery_disabled">Entrega instantânea desativada</string>
     <string name="detail_item_menu_delete">Eliminar ficheiro</string>
-    <string name="detail_item_menu_copy_url_copied">URL copiado para a área de transferência</string>
     <string name="detail_item_menu_copy_contents">Copiar notificação</string>
     <string name="notification_dialog_30min">30 minutos</string>
     <string name="notification_popup_action_open">Abrir</string>
@@ -282,7 +280,6 @@
     <string name="detail_settings_global_setting_suffix">usar configuração global</string>
     <string name="detail_settings_about_header">Sobre a aplicação</string>
     <string name="detail_settings_about_topic_url_title">URL do tópico</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Copiado para a área de transferência</string>
     <string name="user_dialog_title_add">Adicionar utilizador</string>
     <string name="settings_backup_restore_restore_title">Restaurar de um ficheiro</string>
     <string name="settings_backup_restore_restore_summary">Importar configurações, notificações e usuários</string>
@@ -313,7 +310,6 @@
     <string name="settings_advanced_connection_protocol_entry_ws">WebSockets</string>
     <string name="detail_settings_notifications_instant_title">Entrega instantânea</string>
     <string name="detail_settings_notifications_instant_summary_on">As notificações são entregues instantaneamente. Requer um serviço que corre em primeiro plano e consome mais bateria.</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Copiado para área de transferência</string>
     <string name="detail_settings_appearance_icon_error_saving">Não foi possível guardar o ícone: %1$s</string>
     <string name="detail_settings_appearance_icon_remove_summary">Ícone exibido nas notificações deste tópico</string>
     <string name="detail_settings_appearance_display_name_title">Nome de exibição</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -6,7 +6,6 @@
     <string name="settings_advanced_export_logs_error_uploading">Nu s-au putut încărca jurnalele: %1$s</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
     <string name="settings_advanced_connection_protocol_entry_ws">WebSockets</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Copiat în clipboard</string>
     <string name="detail_settings_notifications_instant_summary_on">Notificările sunt primite instantaneu. Necesită un serviciu în prim plan și consumă mai multă baterie.</string>
     <string name="detail_settings_notifications_dedicated_channels_title">Setări personalizate pentru notificări</string>
     <string name="detail_settings_appearance_icon_set_summary">Setează o pictogramă care să fie afișată în notificări</string>
@@ -124,7 +123,6 @@
     <string name="detail_settings_appearance_display_name_default_summary">%1$s (implicit)</string>
     <string name="detail_settings_global_setting_title">Folosește setarea globală</string>
     <string name="detail_settings_about_header">Despre</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Copiat în clipboard</string>
     <string name="detail_settings_global_setting_suffix">folosind setarea globală</string>
     <string name="user_dialog_title_add">Adaugă utilizator</string>
     <string name="user_dialog_title_edit">Modifică utilizator</string>
@@ -184,7 +182,6 @@
     <string name="detail_item_menu_save_file">Salvează fișierul</string>
     <string name="detail_item_saved_successfully">Salvat ca \"%1$s\" în directorul \"Downloads\"</string>
     <string name="detail_item_menu_copy_contents">Copiază notificarea</string>
-    <string name="detail_item_menu_copy_contents_copied">Notificare copiată în clipboard</string>
     <string name="detail_item_cannot_open">Nu se poate deschide atașametul: %1$s</string>
     <string name="detail_item_cannot_open_url">Nu se poate deschide URL-ul: %1$s</string>
     <string name="detail_item_cannot_open_apk">Aplicațiile nu mai pot fi instalate. Descarcă prin intermediul browser-ului. Consultați problema #531 pentru detalii.</string>
@@ -259,7 +256,6 @@
     <string name="detail_clear_dialog_permanently_delete">Șterge permanent</string>
     <string name="detail_clear_dialog_cancel">Anulează</string>
     <string name="detail_item_menu_open">Deschide fișier</string>
-    <string name="detail_item_menu_copy_url_copied">URL copiat în clipboard</string>
     <string name="detail_item_download_info_deleted">șters</string>
     <string name="detail_item_download_info_download_failed">descărcare eșuată</string>
     <string name="detail_item_download_info_download_failed_expired">descărcare eșuată, linkul a expirat</string>
@@ -321,7 +317,7 @@
     <string name="detail_test_message_error_unauthorized_anon">Nu se poate trimite mesajul: Publicarea anonimă nu este permisă.</string>
     <string name="detail_test_message_error_unauthorized_user">Nu se poate trimite mesajul: Utilizatorul \"%1$s\" nu este autorizat.</string>
     <string name="detail_test_message_error_too_large">Nu se poate trimite mesajul: Atașamentul este prea mare.</string>
-    <string name="detail_copied_to_clipboard_message">Copiat în clipboard</string>
+    <string name="common_copied_to_clipboard">Copiat în clipboard</string>
     <string name="detail_instant_delivery_enabled">Primire instantanee pornită</string>
     <string name="detail_instant_delivery_disabled">Primire instantanee oprită</string>
     <string name="main_banner_websocket_button_dismiss">Ignoră</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -24,9 +24,7 @@
     <string name="detail_test_message_error">Не получилось отправить сообщение: %1$s</string>
     <string name="detail_item_menu_save_file">Сохранить файл</string>
     <string name="detail_item_menu_copy_url">Скопировать URL-адрес</string>
-    <string name="detail_item_menu_copy_url_copied">URL-адрес скопирован</string>
     <string name="detail_item_menu_copy_contents">Скопировать уведомление</string>
-    <string name="detail_item_menu_copy_contents_copied">Уведомление скопировано</string>
     <string name="detail_item_saved_successfully">Сохранён как \"%1$s\" в папке \"Downloads\"</string>
     <string name="detail_menu_notifications_disabled_until">Уведомления заглушены до %1$s</string>
     <string name="detail_menu_enable_instant">Включить моментальную доставку</string>
@@ -82,7 +80,7 @@
     <string name="add_dialog_button_cancel">Отмена</string>
     <string name="main_unified_push_toast">Эта подписка управляется %1$s через UnifiedPush</string>
     <string name="detail_item_snack_undo">Отменить</string>
-    <string name="detail_copied_to_clipboard_message">Скопировано в буфер обмена</string>
+    <string name="common_copied_to_clipboard">Скопировано в буфер обмена</string>
     <string name="detail_deep_link_subscribed_toast_message">Подписались на тему %1$s</string>
     <string name="detail_item_tags">Тэги: %1$s</string>
     <string name="detail_item_menu_delete">Удалить файл</string>
@@ -262,7 +260,6 @@
     <string name="settings_about_header">О программе</string>
     <string name="settings_about_version_title">Версия</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Скопировано в буфер обмена</string>
     <string name="user_dialog_title_add">Добавить пользователя</string>
     <string name="user_dialog_title_edit">Редактировать пользователя</string>
     <string name="user_dialog_description_add">Вы можете добавить здесь пользователя. Все темы на заданном сервере будут использовать этого пользователя.</string>
@@ -323,7 +320,6 @@
     <string name="detail_settings_global_setting_suffix">испольует глобальное значение</string>
     <string name="detail_settings_appearance_display_name_message">Выставить произвольный псевдоним для этой подписки. Оставьте пустым чтобы использовать значение по умолчанию (%1$s).</string>
     <string name="detail_settings_appearance_display_name_default_summary">%1$s (по умолчанию)</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Скопирован в буфер обмена</string>
     <string name="detail_settings_notifications_instant_title">Мгновенная доставка</string>
     <string name="detail_settings_notifications_dedicated_channels_title">Пользовательские настройки уведомлений</string>
     <string name="detail_settings_notifications_open_channels_title">Настройки уведомлений</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -83,7 +83,7 @@
     <string name="detail_test_message_error">Kan inte skicka meddelande: %1$s</string>
     <string name="detail_test_message_error_unauthorized_user">Kan inte skicka meddelande: Användaren \"%1$s\" är inte auktoriserad.</string>
     <string name="detail_test_message_error_too_large">Kan inte skicka meddelande: Bilagan är för stor.</string>
-    <string name="detail_copied_to_clipboard_message">Kopierat till urklipp</string>
+    <string name="common_copied_to_clipboard">Kopierat till urklipp</string>
     <string name="detail_instant_delivery_enabled">Omedelbar leverans på</string>
     <string name="detail_instant_delivery_disabled">Omedelbar leverans av</string>
     <string name="detail_deep_link_subscribed_toast_message">Prenumererar på ämne %1$s</string>
@@ -100,9 +100,7 @@
     <string name="add_dialog_login_password_hint">Lösenord</string>
     <string name="detail_test_message_error_unauthorized_anon">Kan inte skicka meddelande: Anonym publicering är inte tillåten.</string>
     <string name="detail_item_snack_deleted">Notifikation borttagen</string>
-    <string name="detail_item_menu_copy_url_copied">URL kopierad till urklipp</string>
     <string name="detail_item_menu_copy_contents">Kopiera notifikation</string>
-    <string name="detail_item_menu_copy_contents_copied">Notifikation kopierad till urklipp</string>
     <string name="detail_item_cannot_open_url">Kan inte öppna URL: %1$s</string>
     <string name="detail_menu_clear">Rensa alla notifikationer</string>
     <string name="detail_menu_test">Skicka testnotifikation</string>
@@ -266,7 +264,6 @@
     <string name="detail_settings_notifications_instant_summary_on">Notifieringarna levereras direkt. Kräver att appen aktivt körs vilket kräver mer batteri.</string>
     <string name="settings_about_version_title">Version</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Kopierad till urklipp</string>
     <string name="detail_settings_appearance_header">Utseende</string>
     <string name="detail_settings_notifications_instant_title">Omedelbar leverans</string>
     <string name="detail_settings_appearance_icon_set_title">Prenumerationsikon</string>
@@ -323,7 +320,6 @@
     <string name="detail_settings_appearance_display_name_message">Sätt ett eget visningsnamn för denna prenumeration. Lämna blank för standard (%1$s).</string>
     <string name="detail_settings_appearance_display_name_default_summary">%1$s (standard)</string>
     <string name="detail_settings_about_topic_url_title">Ämnes-URL</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Kopierad till urklipp</string>
     <string name="user_dialog_title_add">Lägg till användare</string>
     <string name="user_dialog_description_add">Du kan lägga till en användare här. Alla ämnen för den givna servern kommer att använda den här användaren.</string>
     <string name="user_dialog_base_url_hint">Service-URL</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -68,7 +68,7 @@
     <string name="detail_test_message_error">Mesaj gönderilemiyor: %1$s</string>
     <string name="detail_test_message_error_unauthorized_anon">Mesaj gönderilemiyor: Anonim yayına izin verilmiyor.</string>
     <string name="detail_test_message_error_too_large">Mesaj gönderilemiyor: Ek çok büyük.</string>
-    <string name="detail_copied_to_clipboard_message">Panoya kopyalandı</string>
+    <string name="common_copied_to_clipboard">Panoya kopyalandı</string>
     <string name="detail_instant_delivery_enabled">Anında teslimat açık</string>
     <string name="detail_instant_delivery_disabled">Anında teslimat kapalı</string>
     <string name="detail_item_tags">Etiketler: %1$s</string>
@@ -76,7 +76,6 @@
     <string name="detail_item_snack_undo">Geri al</string>
     <string name="detail_item_menu_open">Dosyayı aç</string>
     <string name="detail_item_menu_copy_url">URL\'yi kopyala</string>
-    <string name="detail_item_menu_copy_url_copied">URL panoya kopyalandı</string>
     <string name="detail_item_menu_copy_contents">Bildirimi kopyala</string>
     <string name="detail_item_cannot_download">Ek açılamıyor veya indirilemiyor. Bağlantının süresi doldu ve yerel dosya bulunamadı.</string>
     <string name="detail_item_cannot_open_url">URL açılamıyor: %1$s</string>
@@ -182,7 +181,6 @@
     <string name="settings_about_header">Hakkında</string>
     <string name="settings_about_version_title">Sürüm</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Panoya kopyalandı</string>
     <string name="user_dialog_title_add">Kullanıcı ekle</string>
     <string name="user_dialog_title_edit">Kullanıcıyı düzenle</string>
     <string name="user_dialog_description_add">Buraya bir kullanıcı ekleyebilirsiniz. Verilen sunucu için tüm konular bu kullanıcıyı kullanacaktır.</string>
@@ -219,7 +217,6 @@
     <string name="detail_menu_copy_url">Konu adresini kopyala</string>
     <string name="detail_item_menu_cancel">İndirmeyi iptal et</string>
     <string name="detail_item_menu_save_file">Dosyayı kaydet</string>
-    <string name="detail_item_menu_copy_contents_copied">Bildirim panoya kopyalandı</string>
     <string name="detail_item_cannot_open_not_found">Ek açılamıyor: Dosya silinmiş olabilir veya dosyayı açacak kurulu uygulama yok.</string>
     <string name="detail_item_saved_successfully">İndirilenler klasöründe \"%1$s\" olarak kaydedildi</string>
     <string name="detail_menu_notifications_disabled_forever">Bildirimler sessize alındı</string>
@@ -326,7 +323,6 @@
     <string name="detail_settings_appearance_display_name_message">Bu abonelik için özel bir görünen ad belirleyin. Öntanımlı değer (%1$s) için boş bırakın.</string>
     <string name="detail_settings_about_header">Hakkında</string>
     <string name="detail_settings_about_topic_url_title">Konu URL\'si</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Panoya kopyalandı</string>
     <string name="main_menu_donate_title">Bağış yap 💸</string>
     <string name="detail_item_cannot_open_apk">Uygulamalar artık kurulamıyor. Bunun yerine tarayıcı üzerinden indirin. Ayrıntılar için sorun #531\'e bakın.</string>
     <string name="settings_notifications_insistent_max_priority_summary_disabled">En yüksek öncelikli bildirimler yalnızca bir kez uyarı verir</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -124,7 +124,7 @@
     <string name="detail_test_message">Це тестове сповіщення від програми ntfy для Android. Він має рівень пріоритету %1$d. Якщо ви надішлете інший, він може виглядати інакше.</string>
     <string name="main_how_to_intro">Натисніть +, щоб створити тему або підписатися на неї. Після цього ви отримуєте сповіщення на свій пристрій, коли надсилаєте повідомлення через PUT або POST.</string>
     <string name="add_dialog_login_username_hint">Ім\'я користувача</string>
-    <string name="detail_copied_to_clipboard_message">Скопійовано в буфер обміну</string>
+    <string name="common_copied_to_clipboard">Скопійовано в буфер обміну</string>
     <string name="main_banner_websocket_text">Перехід на WebSockets є рекомендованим способом підключення до вашого сервера, який може подовжити час автономної роботи, але може вимагати <a href="https://ntfy.sh/docs/config/#nginxapache2caddy">додаткової конфігурації вашого проксі</a>. Це можна вимкнути в налаштуваннях.</string>
     <string name="add_dialog_login_title">Необхідно ввійти</string>
     <string name="add_dialog_login_new_user">Новий користувач</string>
@@ -209,7 +209,6 @@
     <string name="detail_settings_about_topic_url_title">URL теми</string>
     <string name="user_dialog_username_hint">Ім\'я користувача</string>
     <string name="detail_settings_about_header">Про</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Скопійовано в буфер обміну</string>
     <string name="user_dialog_description_edit">Ви можете змінити ім\'я користувача/пароль для вибраного користувача або видалити його.</string>
     <string name="user_dialog_button_add">Додати користувача</string>
     <string name="user_dialog_description_add">Ви можете додати користувача тут. Усі теми для даного сервера використовуватимуть цього користувача.</string>
@@ -228,9 +227,7 @@
     <string name="detail_item_menu_open">Відкрити файл</string>
     <string name="detail_item_menu_delete">Видалити файл</string>
     <string name="detail_item_menu_download">Завантажити файл</string>
-    <string name="detail_item_menu_copy_url_copied">URL-адресу скопійовано в буфер обміну</string>
     <string name="detail_item_menu_copy_contents">Копіювати сповіщення</string>
-    <string name="detail_item_menu_copy_contents_copied">Сповіщення скопійовано в буфер обміну</string>
     <string name="detail_item_saved_successfully">Збережено як \"%1$s\" у папці \"Завантаження\"</string>
     <string name="detail_item_cannot_download">Не вдається відкрити або завантажити вкладений файл. Термін дії посилання закінчився, і локальний файл не знайдено.</string>
     <string name="detail_item_cannot_open_not_found">Неможливо відкрити вкладення: файл, можливо, видалено, або жодна встановлена програма не може відкрити файл.</string>
@@ -314,7 +311,6 @@
     <string name="settings_about_header">Про</string>
     <string name="settings_about_version_title">Версія</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Скопійовано в буфер обміну</string>
     <string name="detail_settings_notifications_instant_title">Миттєва доставка</string>
     <string name="detail_settings_appearance_header">Зовнішній вигляд</string>
     <string name="detail_settings_appearance_icon_set_summary">Установіть піктограму, яка відображатиметься в сповіщеннях</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -69,7 +69,7 @@
     <string name="detail_test_message_error">无法发送消息：%1$s</string>
     <string name="detail_test_message_error_unauthorized_anon">无法发送消息：主题禁止匿名发布。</string>
     <string name="detail_test_message_error_too_large">无法发送消息：附件体积过大。</string>
-    <string name="detail_copied_to_clipboard_message">复制到剪贴板</string>
+    <string name="common_copied_to_clipboard">复制到剪贴板</string>
     <string name="detail_instant_delivery_enabled">实时推送已开启</string>
     <string name="detail_instant_delivery_disabled">实时推送已关闭</string>
     <string name="detail_item_tags">标签：%1$s</string>
@@ -79,7 +79,6 @@
     <string name="detail_item_menu_delete">删除文件</string>
     <string name="detail_item_menu_cancel">不再下载</string>
     <string name="detail_item_menu_copy_url">复制链接地址</string>
-    <string name="detail_item_menu_copy_url_copied">链接地址已复制到剪贴板</string>
     <string name="detail_item_menu_copy_contents">复制通知</string>
     <string name="detail_item_saved_successfully">已保存为“下载”目录中的 %1$s</string>
     <string name="detail_item_cannot_download">无法打开或下载附件。此链接已过期且未保存到本地。</string>
@@ -159,7 +158,6 @@
     <string name="detail_item_download_failed">无法下载附件：%1$s</string>
     <string name="detail_item_download_info_not_downloaded">未下载</string>
     <string name="detail_item_download_info_not_downloaded_expired">未下载，链接已失效</string>
-    <string name="detail_item_menu_copy_contents_copied">通知已复制到剪贴板</string>
     <string name="detail_item_cannot_open">无法打开附件：%1$s</string>
     <string name="detail_item_cannot_open_not_found">无法打开附件：此文件已被删除或无可用打开方式。</string>
     <string name="detail_item_cannot_open_url">无法打开链接：%1$s</string>
@@ -282,7 +280,6 @@
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
     <string name="settings_advanced_connection_protocol_entry_ws">WebSockets</string>
     <string name="settings_about_version_title">版本</string>
-    <string name="settings_about_version_copied_to_clipboard_message">已复制到剪贴板</string>
     <string name="user_dialog_description_add">您可以在此添加用户。所有该服务器上的主题订阅都将使用该用户。</string>
     <string name="user_dialog_button_delete">删除用户</string>
     <string name="user_dialog_description_edit">您可以编辑该用户的用户名和密码，或删除该用户。</string>
@@ -326,7 +323,6 @@
     <string name="main_banner_websocket_button_enable_now">马上开启</string>
     <string name="detail_settings_about_header">关于</string>
     <string name="detail_settings_about_topic_url_title">主题 URL</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">已复制到剪贴板</string>
     <string name="main_menu_donate_title">捐赠 💸</string>
     <string name="detail_item_cannot_open_apk">无法再安装应用。 请通过浏览器下载。 有关详细信息，请参阅问题 #531。</string>
     <string name="channel_notifications_group_default_name">默认</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -75,7 +75,7 @@
     <string name="add_dialog_login_new_user">建立新使用者</string>
     <string name="add_dialog_base_urls_dropdown_choose">選擇 ntfy 服務 URL</string>
     <string name="add_dialog_base_urls_dropdown_clear">清除 URL</string>
-    <string name="detail_copied_to_clipboard_message">已複製到剪貼簿</string>
+    <string name="common_copied_to_clipboard">已複製到剪貼簿</string>
     <string name="add_dialog_button_login">登入</string>
     <string name="add_dialog_login_description">這個主題需要登入，請先輸入帳號密碼。</string>
     <string name="add_dialog_instant_delivery">在省電模式下依然接收即時通知</string>
@@ -100,7 +100,6 @@
     <string name="settings_general_default_base_url_default_summary">%1$s (預設)</string>
     <string name="settings_general_users_title">管理使用者</string>
     <string name="settings_backup_restore_header">備份與還原</string>
-    <string name="settings_about_version_copied_to_clipboard_message">已複製到剪貼簿</string>
     <string name="settings_about_header">關於</string>
     <string name="settings_about_version_title">版本號</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
@@ -178,7 +177,6 @@
     <string name="settings_advanced_connection_protocol_entry_jsonhttp">JSON 串流 (透過 HTTP 連接)</string>
     <string name="settings_advanced_connection_protocol_entry_ws">WebSocket</string>
     <string name="detail_settings_about_topic_url_title">主題 URL</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">已複製到剪貼簿</string>
     <string name="user_dialog_password_hint_add">密碼</string>
     <string name="user_dialog_button_save">儲存</string>
     <string name="user_dialog_button_add">新增使用者</string>
@@ -191,7 +189,6 @@
     <string name="detail_settings_about_header">關於</string>
     <string name="settings_backup_restore_backup_failed">備份失敗： %1$s</string>
     <string name="add_dialog_foreground_description">除了 %1$s 以外伺服器有即時傳送。</string>
-    <string name="detail_item_menu_copy_contents_copied">通知已複製至剪貼簿</string>
     <string name="channel_notifications_group_default_name">預設</string>
     <string name="detail_how_to_link">可以再說明書 (ntfy.sh) 找到詳細指示。</string>
     <string name="detail_clear_dialog_message">確定清除主題內的全部通訊？</string>
@@ -218,7 +215,6 @@
     <string name="detail_item_tags">標籤：%1$s</string>
     <string name="detail_instant_delivery_enabled">啟動即時傳送</string>
     <string name="detail_item_menu_copy_url">複製網址</string>
-    <string name="detail_item_menu_copy_url_copied">網址已複製至剪貼簿</string>
     <string name="detail_item_cannot_open">無法開啟附件：%1$s</string>
     <string name="detail_item_cannot_open_not_found">無法開啟附件：檔案可能已被刪除或檔案無法被任何軟件開啟。</string>
     <string name="detail_item_cannot_download">無法開啟或下載附件，網址無效而且找不到本地檔案。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,9 @@
 <resources xmlns:tools="http://schemas.android.com/tools"
            tools:ignore="MissingTranslation">
 
+    <!-- Common strings -->
+    <string name="common_copied_to_clipboard">Copied to clipboard</string>
+
     <!-- Notification channels -->
     <string name="channel_notifications_min_name">Min priority</string>
     <string name="channel_notifications_low_name">Low priority</string>
@@ -133,7 +136,6 @@
     <string name="detail_test_message_error_unauthorized_anon">Cannot send message: Anonymous publishing not allowed.</string>
     <string name="detail_test_message_error_unauthorized_user">Cannot send message: The user \"%1$s\" is not authorized.</string>
     <string name="detail_test_message_error_too_large">Cannot send message: The attachment is too big.</string>
-    <string name="detail_copied_to_clipboard_message">Copied to clipboard</string>
     <string name="detail_instant_delivery_enabled">Instant delivery on</string>
     <string name="detail_instant_delivery_disabled">Instant delivery off</string>
     <string name="detail_deep_link_subscribed_toast_message">Subscribed to topic %1$s</string>
@@ -146,9 +148,7 @@
     <string name="detail_item_menu_cancel">Cancel download</string>
     <string name="detail_item_menu_save_file">Save file</string>
     <string name="detail_item_menu_copy_url">Copy URL</string>
-    <string name="detail_item_menu_copy_url_copied">URL copied to clipboard</string>
     <string name="detail_item_menu_copy_contents">Copy notification</string>
-    <string name="detail_item_menu_copy_contents_copied">Notification copied to clipboard</string>
     <string name="detail_item_saved_successfully">Saved as \"%1$s\" in the \"Downloads\" folder</string>
     <string name="detail_item_cannot_download">Cannot open or download attachment. The link expired and no local file could be found.</string>
     <string name="detail_item_cannot_open">Cannot open attachment: %1$s</string>
@@ -350,7 +350,6 @@
     <string name="settings_about_header">About</string>
     <string name="settings_about_version_title">Version</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
-    <string name="settings_about_version_copied_to_clipboard_message">Copied to clipboard</string>
 
     <!-- Subscription settings (most strings are re-used from above) -->
     <string name="detail_settings_notifications_instant_title">Instant delivery</string>
@@ -376,7 +375,6 @@
     <string name="detail_settings_global_setting_suffix">using global setting</string>
     <string name="detail_settings_about_header">About</string>
     <string name="detail_settings_about_topic_url_title">Topic URL</string>
-    <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Copied to clipboard</string>
 
     <!-- User add/edit dialog -->
     <string name="user_dialog_title_add">Add user</string>


### PR DESCRIPTION
This was originally motivated by removing the duplicate Toast on Android 13:
https://developer.android.com/develop/ui/views/touch-and-input/copy-paste#duplicate-notifications

Notes:

- For the time being, I have left the two instances of special copy handling in the SettingsActivity.
- The string usage can also be centralised.
  - No need to translate the same string multiple times. Also having "URL copied to clipboard" does really not improve the UX over "Copied to clipboard".
  - Only the the English strings.xml is "clean". The other languages are just "rename the most translated generic one, delete the rest".
  - No idea how to import these changes to Weblate.
  - The 2 special strings for the SettingsActivity are kept.

Tested on Android 12 and Android 13.