### PR TITLE
When subscribed to a new_topic, send endpoints to all apps

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/msg/ApiService.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/ApiService.kt
@@ -96,7 +96,7 @@ class ApiService {
             val body = response.body?.string()?.trim()
             if (body.isNullOrEmpty()) return emptyList()
             val notifications = body.lines().mapNotNull { line ->
-                parser.parseNotification(line, subscriptionId = subscriptionId, notificationId = 0) // No notification when we poll
+                parser.parse(line, subscriptionId = subscriptionId, notificationId = 0) // No notification when we poll
             }
 
             Log.d(TAG, "Notifications: $notifications")

--- a/app/src/main/java/io/heckel/ntfy/msg/ApiService.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/ApiService.kt
@@ -11,7 +11,6 @@ import java.io.IOException
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.TimeUnit
-import kotlin.random.Random
 
 class ApiService {
     private val client = OkHttpClient.Builder()
@@ -97,7 +96,7 @@ class ApiService {
             val body = response.body?.string()?.trim()
             if (body.isNullOrEmpty()) return emptyList()
             val notifications = body.lines().mapNotNull { line ->
-                parser.parse(line, subscriptionId = subscriptionId, notificationId = 0) // No notification when we poll
+                parser.parseNotification(line, subscriptionId = subscriptionId, notificationId = 0) // No notification when we poll
             }
 
             Log.d(TAG, "Notifications: $notifications")

--- a/app/src/main/java/io/heckel/ntfy/msg/Message.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/Message.kt
@@ -16,7 +16,7 @@ data class Message(
     val icon: String?,
     val actions: List<MessageAction>?,
     val title: String?,
-    val message: String,
+    val message: String?,
     val encoding: String?,
     val attachment: MessageAttachment?,
 )

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
@@ -6,6 +6,7 @@ import io.heckel.ntfy.db.Action
 import io.heckel.ntfy.db.Attachment
 import io.heckel.ntfy.db.Icon
 import io.heckel.ntfy.db.Notification
+import io.heckel.ntfy.util.Log
 import io.heckel.ntfy.util.joinTags
 import io.heckel.ntfy.util.toPriority
 import java.lang.reflect.Type
@@ -13,13 +14,20 @@ import java.lang.reflect.Type
 class NotificationParser {
     private val gson = Gson()
 
+    fun parseMessage(s: String) : Message? {
+
+        val message= gson.fromJson(s, Message::class.java)
+        Log.d("HITAGME", message.toString())
+        return message
+    }
+
     fun parse(s: String, subscriptionId: Long = 0, notificationId: Int = 0): Notification? {
-        val notificationWithTopic = parseWithTopic(s, subscriptionId = subscriptionId, notificationId = notificationId)
+        val message = parseMessage(s) ?: return null
+        val notificationWithTopic = parseWithTopic(message, subscriptionId = subscriptionId, notificationId = notificationId)
         return notificationWithTopic?.notification
     }
 
-    fun parseWithTopic(s: String, subscriptionId: Long = 0, notificationId: Int = 0): NotificationWithTopic? {
-        val message = gson.fromJson(s, Message::class.java)
+    fun parseWithTopic(message: Message, subscriptionId: Long = 0, notificationId: Int = 0): NotificationWithTopic? {
         if (message.event != ApiService.EVENT_MESSAGE) {
             return null
         }
@@ -56,7 +64,7 @@ class NotificationParser {
             subscriptionId = subscriptionId,
             timestamp = message.time,
             title = message.title ?: "",
-            message = message.message,
+            message = message.message?: "",
             encoding = message.encoding ?: "",
             priority = toPriority(message.priority),
             tags = joinTags(message.tags),

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
@@ -17,7 +17,7 @@ class NotificationParser {
         return gson.fromJson(s, Message::class.java)
     }
 
-    fun parseNotification(s: String, subscriptionId: Long = 0, notificationId: Int = 0): Notification? {
+    fun parse(s: String, subscriptionId: Long = 0, notificationId: Int = 0): Notification? {
         val message = parseMessage(s) ?: return null
         val notificationWithTopic = parseNotificationWithTopic(message, subscriptionId = subscriptionId, notificationId = notificationId)
         return notificationWithTopic?.notification

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
@@ -6,7 +6,6 @@ import io.heckel.ntfy.db.Action
 import io.heckel.ntfy.db.Attachment
 import io.heckel.ntfy.db.Icon
 import io.heckel.ntfy.db.Notification
-import io.heckel.ntfy.util.Log
 import io.heckel.ntfy.util.joinTags
 import io.heckel.ntfy.util.toPriority
 import java.lang.reflect.Type
@@ -15,19 +14,16 @@ class NotificationParser {
     private val gson = Gson()
 
     fun parseMessage(s: String) : Message? {
-
-        val message= gson.fromJson(s, Message::class.java)
-        Log.d("HITAGME", message.toString())
-        return message
+        return gson.fromJson(s, Message::class.java)
     }
 
-    fun parse(s: String, subscriptionId: Long = 0, notificationId: Int = 0): Notification? {
+    fun parseNotification(s: String, subscriptionId: Long = 0, notificationId: Int = 0): Notification? {
         val message = parseMessage(s) ?: return null
-        val notificationWithTopic = parseWithTopic(message, subscriptionId = subscriptionId, notificationId = notificationId)
+        val notificationWithTopic = parseNotificationWithTopic(message, subscriptionId = subscriptionId, notificationId = notificationId)
         return notificationWithTopic?.notification
     }
 
-    fun parseWithTopic(message: Message, subscriptionId: Long = 0, notificationId: Int = 0): NotificationWithTopic? {
+    fun parseNotificationWithTopic(message: Message, subscriptionId: Long = 0, notificationId: Int = 0): NotificationWithTopic? {
         if (message.event != ApiService.EVENT_MESSAGE) {
             return null
         }

--- a/app/src/main/java/io/heckel/ntfy/service/JsonConnection.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/JsonConnection.kt
@@ -4,12 +4,10 @@ import io.heckel.ntfy.db.*
 import io.heckel.ntfy.util.Log
 import io.heckel.ntfy.msg.ApiService
 import io.heckel.ntfy.msg.Message
-import io.heckel.ntfy.msg.NotificationParser
 import io.heckel.ntfy.util.topicUrl
 import kotlinx.coroutines.*
 import okhttp3.Call
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.random.Random
 
 class JsonConnection(
     private val connectionId: ConnectionId,

--- a/app/src/main/java/io/heckel/ntfy/service/JsonConnection.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/JsonConnection.kt
@@ -43,7 +43,7 @@ class JsonConnection(
             while (isActive && serviceActive()) {
                 Log.d(TAG, "[$url] (Re-)starting connection for subscriptions: $topicsToSubscriptionIds")
                 val startTime = System.currentTimeMillis()
-                val notify = notify@ { message : Message ->
+                val notify = { message : Message ->
                         since = notificationListener(ConnectionId(baseUrl, topicsToSubscriptionIds, topicIsUnifiedPush), message)?: since
                 }
                 val failed = AtomicBoolean(false)

--- a/app/src/main/java/io/heckel/ntfy/service/SubscriberService.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/SubscriberService.kt
@@ -257,10 +257,9 @@ class SubscriberService : Service() {
             GlobalScope.launch(Dispatchers.IO) {
                 for (topic in connectionId.topicsToSubscriptionIds.keys) {
                     if (connectionId.topicIsUnifiedPush[topic] == true) {
-                        io.heckel.ntfy.up.BroadcastReceiver.sendRegistration(baseContext, connectionId.baseUrl, topic)
-                        // TODO is that the right context
-                        // looks like it works???
                         Log.d(TAG, "Attempting to re-register ${connectionId.baseUrl}/$topic")
+                        io.heckel.ntfy.up.BroadcastReceiver.sendRegistration(baseContext, connectionId.baseUrl, topic)
+                        // TODO is that the right context - looks like it works???
                     }
                 }
             }

--- a/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
@@ -5,7 +5,6 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import io.heckel.ntfy.db.*
-import io.heckel.ntfy.msg.ApiService
 import io.heckel.ntfy.msg.ApiService.Companion.requestBuilder
 import io.heckel.ntfy.msg.Message
 import io.heckel.ntfy.msg.NotificationParser
@@ -20,7 +19,6 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.random.Random
 
 /**
  * Connect to ntfy server via WebSockets. This connection represents a single connection to a server, with

--- a/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
@@ -61,8 +61,8 @@ class WsConnection(
     private val topicIsUnifiedPush = connectionId.topicIsUnifiedPush
     private val subscriptionIds = topicsToSubscriptionIds.values
     private val topicsStr = topicsToSubscriptionIds.keys.joinToString(separator = ",")
-    private val unifiedPushTopicsStr =
-        topicIsUnifiedPush.filter { entry -> entry.value }.keys.joinToString(separator = ",")
+    private val unifiedPushTopicsStr = topicIsUnifiedPush.filter { entry -> entry.value
+}.keys.joinToString(separator = ",")
     private val shortUrl = topicShortUrl(baseUrl, topicsStr)
 
     init {

--- a/app/src/main/java/io/heckel/ntfy/up/BroadcastReceiver.kt
+++ b/app/src/main/java/io/heckel/ntfy/up/BroadcastReceiver.kt
@@ -100,7 +100,7 @@ class BroadcastReceiver : android.content.BroadcastReceiver() {
                     without a connection to the push server.
                     Unless the app sends registration twice. Then it'll get the endpoint.*/
 
-                    //Refresh (and maybe start) foreground service
+                    // Refresh (and maybe start) foreground service
                     SubscriberServiceManager.refresh(app)
                 } catch (e: Exception) {
                     Log.w(TAG, "Failed to add subscription", e)

--- a/app/src/main/java/io/heckel/ntfy/up/BroadcastReceiver.kt
+++ b/app/src/main/java/io/heckel/ntfy/up/BroadcastReceiver.kt
@@ -97,7 +97,8 @@ class BroadcastReceiver : android.content.BroadcastReceiver() {
                     registering with the push server. This avoids a race condition where the application server
                     is rejected before ntfy even establishes that this topic exists.
                     This is fine from an application perspective, because other distributors can't even register
-                    without a connection to the push server. */
+                    without a connection to the push server.
+                    Unless the app sends registration twice. Then it'll get the endpoint.*/
 
                     //Refresh (and maybe start) foreground service
                     SubscriberServiceManager.refresh(app)
@@ -164,7 +165,6 @@ class BroadcastReceiver : android.content.BroadcastReceiver() {
                     val appId = existingSubscription.upAppId ?: return@launch
                     val connectorToken = existingSubscription.upConnectorToken ?: return@launch
                     val endpoint = topicUrlUp(existingSubscription.baseUrl, existingSubscription.topic)
-                    Log.d(TAG, "Sending endpoint $endpoint to ${existingSubscription.upAppId}")
                     distributor.sendEndpoint(appId, connectorToken, endpoint)
                 }
             }

--- a/app/src/main/java/io/heckel/ntfy/up/BroadcastReceiver.kt
+++ b/app/src/main/java/io/heckel/ntfy/up/BroadcastReceiver.kt
@@ -93,12 +93,14 @@ class BroadcastReceiver : android.content.BroadcastReceiver() {
                 try {
                     // Note, this may fail due to a SQL constraint exception, see https://github.com/binwiederhier/ntfy/issues/185
                     repository.addSubscription(subscription)
-                    /* We don't send the endpoint here anymore, the foreground service will do that after
-                    registering with the push server. This avoids a race condition where the application server
+                    distributor.sendEndpoint(appId, connectorToken, endpoint)
+                    /* We need to stop sending the endpoint here once everyone has the new server,
+                    the foreground service will do that after registering with the server.
+                    That will avoid a race condition where the application server
                     is rejected before ntfy even establishes that this topic exists.
                     This is fine from an application perspective, because other distributors can't even register
                     without a connection to the push server.
-                    Unless the app sends registration twice. Then it'll get the endpoint.*/
+                    Unless the app registers twice. Then it'll get the endpoint anyway.*/
 
                     // Refresh (and maybe start) foreground service
                     SubscriberServiceManager.refresh(app)


### PR DESCRIPTION
Also needs cleaning and organization, but I'm opening this because I'm very excited to finally have something that works. So we previously discussed that I would do it using just timing data on the app because that would be simpler, but it really was not. Keeping track of the connection state was a whole thing and the worst thing is that it didn't solve the problem of losing the connection on server restart. This implementation only sends out new_endpoint after subscribing to the topic on the ntfy server.
Goes along with https://github.com/binwiederhier/ntfy/pull/979