### PR TITLE
wip: Allow wakelock to timeout naturally

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/service/SubscriberService.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/SubscriberService.kt
@@ -263,11 +263,6 @@ class SubscriberService : Service() {
                 Log.d(TAG, "[$url] Dispatching notification $notification")
                 dispatcher.dispatch(subscription, notification)
             }
-            wakeLock?.let {
-                if (it.isHeld) {
-                    it.release()
-                }
-            }
         }
     }
 
@@ -355,7 +350,7 @@ class SubscriberService : Service() {
         private const val NOTIFICATION_CHANNEL_ID = "ntfy-subscriber"
         private const val NOTIFICATION_GROUP_ID = "io.heckel.ntfy.NOTIFICATION_GROUP_SERVICE"
         private const val NOTIFICATION_SERVICE_ID = 2586
-        private const val NOTIFICATION_RECEIVED_WAKELOCK_TIMEOUT_MILLIS = 10*60*1000L /*10 minutes*/
+        private const val NOTIFICATION_RECEIVED_WAKELOCK_TIMEOUT_MILLIS = 3*1000L /*3 seconds*/
         private const val SHARED_PREFS_ID = "SubscriberService"
         private const val SHARED_PREFS_SERVICE_STATE = "ServiceState"
 


### PR DESCRIPTION
When an intent is sent off after a notification event is received, the receiver may not obtain their own wakelock.  In that event, despite the near-instant delivery of a push notification, the event receiver may yet still need to wait for the phone to wake again in order to actually act on the notification.

In this patch, we employ the existing `NOTIFICATION_RECEIVED_WAKELOCK_TIMEOUT_MILLIS` value that controls the length of time the wakelock is held before expiring.  Normally, this would never occur, instead the lock is released at the end of our processing of the event.  However, when we release it, the receiving applications lose their ability to act before the device is accidentally woken for some other reason.  Instead, we set this timeout to a more reasonable value of 3 seconds, and do NOT release it ourselves.  This means that the receiving applications have around 3 seconds to act before the wakelock expires.

This is less than ideal: the receiving applications should know whether or not their response deserves a wakelock, and they should themselves get and hold it until they are satisfied.  However, this works around buggy AOSP versions and applications that do not implement this more ideal behavior.