### PR TITLE
Add image/webp to supportImage mimeType list

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/util/Util.kt
+++ b/app/src/main/java/io/heckel/ntfy/util/Util.kt
@@ -333,7 +333,7 @@ fun mimeTypeToIconResource(mimeType: String?): Int {
 }
 
 fun supportedImage(mimeType: String?): Boolean {
-    return listOf("image/jpeg", "image/png").contains(mimeType)
+    return listOf("image/jpeg", "image/png", "image/webp").contains(mimeType)
 }
 
 // Google Play doesn't allow us to install received .apk files anymore.


### PR DESCRIPTION
Add image/webp mime type to supported list. webp images are correctly shown that way.