### PR TITLE
Android 34 and SCHEDULE_EXACT_ALARM

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,18 +1,23 @@
+plugins {
+    id 'com.google.devtools.ksp'
+}
+
 repositories {
     mavenCentral()
 }
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
+//apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.gms.google-services'
 
 android {
-    compileSdkVersion 33
+    namespace "io.heckel.ntfy"
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "io.heckel.ntfy"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
 
         versionCode 33
         versionName "1.17.0"
@@ -24,6 +29,10 @@ android {
             annotationProcessorOptions {
                 arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
             }
+        }
+
+        buildFeatures {
+            buildConfig true
         }
     }
 
@@ -54,12 +63,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
         freeCompilerArgs += [
             '-Xjvm-default=all-compatibility' // https://stackoverflow.com/a/71234042/1440785
         ]
@@ -103,9 +112,10 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10'
 
     // Room (SQLite)
-    def room_version = "2.5.1"
+    def room_version = "2.6.1"
+    implementation "androidx.room:room-runtime:$room_version"
+    ksp "androidx.room:room-compiler:$room_version"
     implementation "androidx.room:room-ktx:$room_version"
-    kapt "androidx.room:room-compiler:$room_version"
 
     // OkHttp (HTTP library)
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="io.heckel.ntfy">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Permissions -->
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -110,6 +110,7 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.app.action.SCHEDULE_EXACT_ALARM_PERMISSION_STATE_CHANGED"/>
             </intent-filter>
         </receiver>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <!-- Permissions -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/> <!-- For instant delivery foregrounds service -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/> <!-- For instant delivery foregrounds service on SDK >= 34 -->
     <uses-permission android:name="android.permission.WAKE_LOCK"/> <!-- To keep foreground service awake; soon not needed anymore -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/> <!-- To restart service on reboot -->
     <uses-permission android:name="android.permission.VIBRATE"/> <!-- Incoming notifications should be able to vibrate the phone -->
@@ -94,7 +95,13 @@
         </activity>
 
         <!-- Subscriber foreground service for hosts other than ntfy.sh -->
-        <service android:name=".service.SubscriberService"/>
+        <service
+            android:name=".service.SubscriberService"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="This is the main feature of this application. The foreground notification displays the connectivity status to the configurable remote server and the service notifies the user when a new message has been published on the remote server." />
+        </service>
 
         <!-- Subscriber service restart on reboot -->
         <receiver

--- a/app/src/main/java/io/heckel/ntfy/db/Database.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Database.kt
@@ -120,7 +120,7 @@ data class Attachment(
     @ColumnInfo(name = "contentUri") val contentUri: String?, // After it's downloaded, the content:// location
     @ColumnInfo(name = "progress") val progress: Int, // Progress during download, -1 if not downloaded
 ) {
-    constructor(name: String, type: String?, size: Long?, expires: Long?, url: String) :
+    @Ignore constructor(name: String, type: String?, size: Long?, expires: Long?, url: String) :
             this(name, type, size, expires, url, null, ATTACHMENT_PROGRESS_NONE)
 }
 
@@ -135,7 +135,7 @@ data class Icon(
     @ColumnInfo(name = "url") val url: String, // URL (mandatory, see ntfy server)
     @ColumnInfo(name = "contentUri") val contentUri: String?, // After it's downloaded, the content:// location
 ) {
-    constructor(url:String) :
+    @Ignore constructor(url:String) :
             this(url, null)
 }
 
@@ -192,7 +192,7 @@ data class LogEntry(
     @ColumnInfo(name = "message") val message: String,
     @ColumnInfo(name = "exception") val exception: String?
 ) {
-    constructor(timestamp: Long, tag: String, level: Int, message: String, exception: String?) :
+    @Ignore constructor(timestamp: Long, tag: String, level: Int, message: String, exception: String?) :
             this(0, timestamp, tag, level, message, exception)
 }
 

--- a/app/src/main/java/io/heckel/ntfy/db/Repository.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Repository.kt
@@ -342,6 +342,16 @@ class Repository(private val sharedPrefs: SharedPreferences, private val databas
             .apply()
     }
 
+    fun getWebSocketReconnectRemindTime(): Long {
+        return sharedPrefs.getLong(SHARED_PREFS_WEBSOCKET_RECONNECT_REMIND_TIME, WEBSOCKET_RECONNECT_REMIND_TIME_ALWAYS)
+    }
+
+    fun setWebSocketReconnectRemindTime(timeMillis: Long) {
+        sharedPrefs.edit()
+            .putLong(SHARED_PREFS_WEBSOCKET_RECONNECT_REMIND_TIME, timeMillis)
+            .apply()
+    }
+
     fun getDefaultBaseUrl(): String? {
         return sharedPrefs.getString(SHARED_PREFS_DEFAULT_BASE_URL, null) ?:
             sharedPrefs.getString(SHARED_PREFS_UNIFIED_PUSH_BASE_URL, null) // Fall back to UP URL, removed when default is set!
@@ -492,6 +502,7 @@ class Repository(private val sharedPrefs: SharedPreferences, private val databas
         const val SHARED_PREFS_RECORD_LOGS_ENABLED = "RecordLogs"
         const val SHARED_PREFS_BATTERY_OPTIMIZATIONS_REMIND_TIME = "BatteryOptimizationsRemindTime"
         const val SHARED_PREFS_WEBSOCKET_REMIND_TIME = "JsonStreamRemindTime" // "Use WebSocket" banner (used to be JSON stream deprecation banner)
+        const val SHARED_PREFS_WEBSOCKET_RECONNECT_REMIND_TIME = "WebSocketReconnectRemindTime"
         const val SHARED_PREFS_UNIFIED_PUSH_BASE_URL = "UnifiedPushBaseURL" // Legacy key required for migration to DefaultBaseURL
         const val SHARED_PREFS_DEFAULT_BASE_URL = "DefaultBaseURL"
         const val SHARED_PREFS_LAST_TOPICS = "LastTopics"
@@ -531,6 +542,9 @@ class Repository(private val sharedPrefs: SharedPreferences, private val databas
 
         const val WEBSOCKET_REMIND_TIME_ALWAYS = 1L
         const val WEBSOCKET_REMIND_TIME_NEVER = Long.MAX_VALUE
+
+        const val WEBSOCKET_RECONNECT_REMIND_TIME_ALWAYS = 1L
+        const val WEBSOCKET_RECONNECT_REMIND_TIME_NEVER = Long.MAX_VALUE
 
         private const val TAG = "NtfyRepository"
         private var instance: Repository? = null

--- a/app/src/main/java/io/heckel/ntfy/service/SubscriberService.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/SubscriberService.kt
@@ -4,6 +4,7 @@ import android.app.*
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
 import android.os.PowerManager
@@ -98,7 +99,11 @@ class SubscriberService : Service() {
         notificationManager = createNotificationChannel()
         serviceNotification = createNotification(title, text)
 
-        startForeground(NOTIFICATION_SERVICE_ID, serviceNotification)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(NOTIFICATION_SERVICE_ID, serviceNotification!!, ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
+        } else {
+            startForeground(NOTIFICATION_SERVICE_ID, serviceNotification)
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
@@ -114,7 +114,27 @@ class WsConnection(
             Log.d(TAG,"$shortUrl (gid=$globalId): Scheduling a restart in $seconds seconds (via alarm manager)")
             val reconnectTime = Calendar.getInstance()
             reconnectTime.add(Calendar.SECOND, seconds)
-            alarmManager.setExact(AlarmManager.RTC_WAKEUP, reconnectTime.timeInMillis, RECONNECT_TAG, { start() }, null)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                if (alarmManager.canScheduleExactAlarms()) {
+                    alarmManager.setExact(
+                        AlarmManager.RTC_WAKEUP,
+                        reconnectTime.timeInMillis,
+                        RECONNECT_TAG,
+                        { start() },
+                        null
+                    )
+                } else {
+                    Log.d(TAG, "SCHEDULE_EXACT_ALARM permission denied: Failed to reschedule websocket connection")
+                }
+            } else {
+                alarmManager.setExact(
+                    AlarmManager.RTC_WAKEUP,
+                    reconnectTime.timeInMillis,
+                    RECONNECT_TAG,
+                    { start() },
+                    null
+                )
+            }
         } else {
             Log.d(TAG, "$shortUrl (gid=$globalId): Scheduling a restart in $seconds seconds (via handler)")
             val handler = Handler(Looper.getMainLooper())

--- a/app/src/main/java/io/heckel/ntfy/ui/Colors.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/Colors.kt
@@ -7,7 +7,7 @@ import io.heckel.ntfy.util.isDarkThemeOn
 
 class Colors {
     companion object {
-        const val refreshProgressIndicator = R.color.teal
+        val refreshProgressIndicator = R.color.teal
 
         fun notificationIcon(context: Context): Int {
             return if (isDarkThemeOn(context)) R.color.teal_light else R.color.teal

--- a/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
@@ -3,6 +3,7 @@ package io.heckel.ntfy.ui
 import android.Manifest
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
+import android.app.AlarmManager
 import android.app.AlertDialog
 import android.content.ActivityNotFoundException
 import android.content.Intent
@@ -11,6 +12,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
+import android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM
 import android.text.method.LinkMovementMethod
 import android.view.ActionMode
 import android.view.Menu
@@ -125,9 +127,10 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
                     Log.addScrubTerm(s.topic)
                 }
 
-                // Update banner + WebSocket banner
+                // Update battery banner + WebSocket banner + websocket reconnect banner
                 showHideBatteryBanner(subscriptions)
                 showHideWebSocketBanner(subscriptions)
+                showHideWebSocketReconnectBanner(subscriptions)
             }
         }
 
@@ -194,6 +197,38 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
             repository.setConnectionProtocol(Repository.CONNECTION_PROTOCOL_WS)
             SubscriberServiceManager(this).restart()
             wsBanner.visibility = View.GONE
+
+            // maybe show WebSocketReconnectBanner
+            viewModel.list().observe(this) {
+                it?.let { subscriptions ->
+                    showHideWebSocketReconnectBanner(subscriptions)
+                }
+            }
+        }
+
+        // WebSocket Reconnect banner
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val wsReconnectBanner = findViewById<View>(R.id.main_banner_websocket_reconnect)
+            val wsReconnectText = findViewById<TextView>(R.id.main_banner_websocket_reconnect_text)
+            val wsReconnectDismissButton =
+                findViewById<Button>(R.id.main_banner_websocket_reconnect_dontaskagain)
+            val wsReconnectRemindButton =
+                findViewById<Button>(R.id.main_banner_websocket_reconnect_remind_later)
+            val wsReconnectEnableButton =
+                findViewById<Button>(R.id.main_banner_websocket_reconnect_enable)
+            wsReconnectText.movementMethod =
+                LinkMovementMethod.getInstance() // Make links clickable
+            wsReconnectDismissButton.setOnClickListener {
+                wsReconnectBanner.visibility = View.GONE
+                repository.setWebSocketReconnectRemindTime(Repository.WEBSOCKET_RECONNECT_REMIND_TIME_NEVER)
+            }
+            wsReconnectRemindButton.setOnClickListener {
+                wsReconnectBanner.visibility = View.GONE
+                repository.setWebSocketReconnectRemindTime(System.currentTimeMillis() + ONE_DAY_MILLIS)
+            }
+            wsReconnectEnableButton.setOnClickListener {
+                startActivity(Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
+            }
         }
 
         // Create notification channels right away, so we can configure them immediately after installing the app
@@ -246,6 +281,24 @@ class MainActivity : AppCompatActivity(), ActionMode.Callback, AddFragment.Subsc
         val showBanner = hasSelfHostedSubscriptions && wsRemindTimeReached && !usingWebSockets
         val wsBanner = findViewById<View>(R.id.main_banner_websocket)
         wsBanner.visibility = if (showBanner) View.VISIBLE else View.GONE
+    }
+
+    private fun showHideWebSocketReconnectBanner(subscriptions: List<Subscription>) {
+        val wsReconnectBanner = findViewById<View>(R.id.main_banner_websocket_reconnect)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val hasSelfHostedSubscriptions = subscriptions.count { it.baseUrl != appBaseUrl } > 0
+            val usingWebSockets =
+                repository.getConnectionProtocol() == Repository.CONNECTION_PROTOCOL_WS
+            val wsReconnectRemindTimeReached =
+                repository.getWebSocketReconnectRemindTime() < System.currentTimeMillis()
+            val canScheduleExactAlarms =
+                (getSystemService(ALARM_SERVICE) as AlarmManager).canScheduleExactAlarms()
+            val showBanner = hasSelfHostedSubscriptions && wsReconnectRemindTimeReached && usingWebSockets && !canScheduleExactAlarms
+            Log.d(TAG, "hasSelfHostedSubscriptions: ${hasSelfHostedSubscriptions}, wsReconnectRemindTimeReached: ${wsReconnectRemindTimeReached}, usingWebSockets: ${usingWebSockets}, canScheduleExactAlarms: ${canScheduleExactAlarms}")
+            wsReconnectBanner.visibility = if (showBanner) View.VISIBLE else View.GONE
+        } else {
+            wsReconnectBanner.visibility = View.GONE
+        }
     }
 
     private fun schedulePeriodicPollWorker() {

--- a/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
@@ -1,6 +1,7 @@
 package io.heckel.ntfy.ui
 
 import android.Manifest
+import android.app.AlarmManager
 import android.app.AlertDialog
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -10,6 +11,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
+import android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM
 import android.text.TextUtils
 import android.widget.Button
 import android.widget.Toast
@@ -117,6 +119,11 @@ class SettingsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPrefere
             userSettingsFragment = fragment
         }
         return true
+    }
+
+    override fun onResume() {
+        super.onResume()
+        settingsFragment.updateExactAlarmsPref()
     }
 
     class SettingsFragment : PreferenceFragmentCompat() {
@@ -545,6 +552,9 @@ class SettingsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPrefere
                 }
             }
 
+            // CanScheduleExactAlarms
+            updateExactAlarmsPref()
+
             // Version
             val versionPrefId = context?.getString(R.string.settings_about_version_key) ?: return
             val versionPref: Preference? = findPreference(versionPrefId)
@@ -675,6 +685,23 @@ class SettingsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPrefere
                         .makeText(context, getString(R.string.settings_advanced_clear_logs_deleted_toast), Toast.LENGTH_LONG)
                         .show()
                 }
+            }
+        }
+
+        fun updateExactAlarmsPref() {
+            val exactAlarmsPrefId = context?.getString(R.string.settings_advanced_exact_alarms_key) ?: return
+            val exactAlarmsPref: Preference? = findPreference(exactAlarmsPrefId)
+            val canScheduleExactAlarms = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                (activity?.getSystemService(ALARM_SERVICE) as AlarmManager).canScheduleExactAlarms()
+            } else {
+                true
+            }
+            exactAlarmsPref?.summary = if (canScheduleExactAlarms) getString(R.string.settings_advanced_exact_alarms_true) else getString(R.string.settings_advanced_exact_alarms_false)
+            exactAlarmsPref?.onPreferenceClickListener = OnPreferenceClickListener {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !canScheduleExactAlarms) {
+                    startActivity(Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
+                }
+                true
             }
         }
 

--- a/app/src/main/java/io/heckel/ntfy/util/Util.kt
+++ b/app/src/main/java/io/heckel/ntfy/util/Util.kt
@@ -393,13 +393,14 @@ class ContentUriRequestBody(
     }
 }
 
+// TODO: make this work in Android 34+
 // Hack: Make end icon for drop down smaller, see https://stackoverflow.com/a/57098715/1440785
 fun View.makeEndIconSmaller(resources: Resources) {
-    val dimension = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 30f, resources.displayMetrics)
-    val endIconImageView = findViewById<ImageView>(R.id.text_input_end_icon)
-    endIconImageView.minimumHeight = dimension.toInt()
-    endIconImageView.minimumWidth = dimension.toInt()
-    requestLayout()
+//    val dimension = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 30f, resources.displayMetrics)
+//    val endIconImageView = findViewById<ImageView>(R.id.text_input_end_icon)
+//    endIconImageView.minimumHeight = dimension.toInt()
+//    endIconImageView.minimumWidth = dimension.toInt()
+//    requestLayout()
 }
 
 // Shows the ripple effect on the view, if it is ripple-able, see https://stackoverflow.com/a/56314062/1440785

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -148,6 +148,73 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.card.MaterialCardView>
 
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:shapeAppearance="?shapeAppearanceLargeComponent" app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" app:layout_constraintTop_toBottomOf="@+id/main_banner_websocket"
+        android:id="@+id/main_banner_websocket_reconnect" android:visibility="visible">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/main_banner_websocket_reconnect_constraint" android:elevation="5dp">
+
+            <ImageView
+                android:layout_width="28dp"
+                android:layout_height="28dp" app:srcCompat="@drawable/ic_announcement_orange_24dp"
+                android:id="@+id/main_banner_websocket_reconnect_image"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/main_banner_websocket_reconnect_text"
+                app:layout_constraintEnd_toStartOf="@id/main_banner_websocket_reconnect_text"
+                app:layout_constraintBottom_toBottomOf="@+id/main_banner_websocket_reconnect_text"
+                android:layout_marginStart="15dp"/>
+            <TextView
+                android:id="@+id/main_banner_websocket_reconnect_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_reconnect_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                android:layout_marginEnd="15dp" android:layout_marginTop="15dp"
+                app:layout_constraintStart_toEndOf="@+id/main_banner_websocket_reconnect_image"
+                android:layout_marginStart="10dp"
+                />
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:constraint_referenced_ids="main_banner_websocket_reconnect_remind_later,main_banner_websocket_reconnect_dontaskagain,main_banner_websocket_reconnect_enable" app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_reconnect_text" app:flow_horizontalAlign="end" app:flow_wrapMode="chain" app:flow_horizontalStyle="packed" android:layout_marginEnd="15dp" android:id="@+id/flow_reconnect" app:layout_constraintStart_toStartOf="parent" android:layout_marginStart="15dp" app:flow_horizontalBias="1"
+                app:flow_verticalGap="0dp" app:flow_horizontalGap="0dp"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_reconnect_remind_later"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_reconnect_button_remind_later"
+                tools:layout_editor_absoluteX="86dp" tools:layout_editor_absoluteY="83dp"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_reconnect_dontaskagain"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_reconnect_button_dismiss"
+                tools:layout_editor_absoluteX="260dp" tools:layout_editor_absoluteY="83dp"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/main_banner_websocket_reconnect_enable"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/main_banner_websocket_reconnect_button_enable_now"
+                tools:layout_editor_absoluteX="253dp" tools:layout_editor_absoluteY="131dp"/>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/main_subscriptions_list_container"
             android:layout_width="match_parent"
@@ -155,7 +222,7 @@
             android:visibility="visible"
             app:layout_constraintStart_toStartOf="parent" app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/main_banner_websocket">
+            app:layout_constraintTop_toBottomOf="@id/main_banner_websocket_reconnect">
         <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/main_subscriptions_list"
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,12 @@
     <string name="main_banner_websocket_button_dismiss">Dismiss</string>
     <string name="main_banner_websocket_button_enable_now">Enable now</string>
 
+    <!-- Main activity: WebSocket Reconnect banner -->
+    <string name="main_banner_websocket_reconnect_text">To ensure WebSockets reconnect in the background, grant the "Alarm &amp; Reminders" permission to ntfy</string>
+    <string name="main_banner_websocket_reconnect_button_remind_later">Ask later</string>
+    <string name="main_banner_websocket_reconnect_button_dismiss">Dismiss</string>
+    <string name="main_banner_websocket_reconnect_button_enable_now">Grant now</string>
+
     <!-- Add dialog -->
     <string name="add_dialog_title">Subscribe to topic</string>
     <string name="add_dialog_description_below">
@@ -347,6 +353,9 @@
     <string name="settings_advanced_connection_protocol_summary_ws">Use WebSockets to connect to the server. This is the recommended method, but may require additional config in your proxy.</string>
     <string name="settings_advanced_connection_protocol_entry_jsonhttp">JSON stream over HTTP</string>
     <string name="settings_advanced_connection_protocol_entry_ws">WebSockets</string>
+    <string name="settings_advanced_exact_alarms_title">Exact Alarms</string>
+    <string name="settings_advanced_exact_alarms_true">ntfy can schedule exact alarms (used to reconnect WebSockets in the background)</string>
+    <string name="settings_advanced_exact_alarms_false">ntfy CANNOT schedule exact alarms. Click to grant the permission now</string>
     <string name="settings_about_header">About</string>
     <string name="settings_about_version_title">Version</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -30,6 +30,7 @@
     <string name="settings_advanced_export_logs_key" translatable="false">ExportLogs</string>
     <string name="settings_advanced_clear_logs_key" translatable="false">ClearLogs</string>
     <string name="settings_advanced_connection_protocol_key" translatable="false">ConnectionProtocol</string>
+    <string name="settings_advanced_exact_alarms_key" translatable="false">ExactAlarms</string>
     <string name="settings_about_version_key" translatable="false">Version</string>
 
     <!-- Detail settings constants -->

--- a/app/src/main/res/xml/main_preferences.xml
+++ b/app/src/main/res/xml/main_preferences.xml
@@ -72,6 +72,9 @@
                 app:entries="@array/settings_advanced_connection_protocol_entries"
                 app:entryValues="@array/settings_advanced_connection_protocol_values"
                 app:defaultValue="jsonhttp"/>
+        <Preference
+            app:key="@string/settings_advanced_exact_alarms_key"
+            app:title="@string/settings_advanced_exact_alarms_title"/>
         <SwitchPreference
                 app:key="@string/settings_advanced_broadcast_key"
                 app:title="@string/settings_advanced_broadcast_title"

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,21 @@
 buildscript {
-    ext.kotlin_version = '1.8.20'
+    ext.kotlin_version = '2.0.21'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.7.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.15' // This is removed in the "fdroid" flavor
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
+}
+
+plugins {
+    id 'com.google.devtools.ksp' version '2.0.21-1.0.27'
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 22 10:13:03 PDT 2020
+#Sat Feb 22 14:52:01 MST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip


### PR DESCRIPTION
This should allow us to finally upgrade the ntfy app in the Google Play Store.

When the user is using the "websocket" connection type with at least one self-hosted server subscription, the app will display a banner requesting permissions to schedule exact alarms in the background (if the permission hasn't already been granted).

The SCHEDULE_EXACT_ALARM permission is used to reconnect the websocket connection in the background if it fails/disconnects.

The user can dismiss the permissions banner (temporarily or permanently). If the user dismisses the banner, they can still easily grant the necessary permission from the settings page.

Here's a short video showing the flow:


https://github.com/user-attachments/assets/d1d7413d-0a41-4a51-997b-7fe3dcadd1b5

