### PR TITLE
Disable client-initiated websocket ping as a puzzle piece to 2-3x longer battery life

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
@@ -42,7 +42,7 @@ class WsConnection(
     private val parser = NotificationParser()
     private val client = OkHttpClient.Builder()
         .readTimeout(0, TimeUnit.MILLISECONDS)
-        .pingInterval(1, TimeUnit.MINUTES) // The server pings us too, so this doesn't matter much
+        .pingInterval(0, TimeUnit.MILLISECONDS) // The server pings us, don't need to ping ourselves
         .connectTimeout(10, TimeUnit.SECONDS)
         .build()
     private var errorCount = 0


### PR DESCRIPTION
I've recently switched to ntfy-android on my phone as a unifiedpush provider and noticed a moderate improvement in battery life (due to fewer applications holding an open websocket), but was not overwhelmed by the savings. I noticed that the network connection still consumes a lot of battery (according to my phone's battery usage reporting) and stumbled upon a [blog post](https://blog.wirelessmoves.com/2024/08/ntfy-and-it-keep-alives.html) which in short reports that the default keepalive-interval (45s) is barely enough for the phone's modem to power down and thus save battery.

I've had a look at the server and app implementations and noticed two things:
 * The sensible keepalive-interval limit according to the documentation (77s) is not relevant for the websocket-based implementation.
 * A longer keepalive-interval however still does not allow the modem to power down due to the client-initiated pings.

This PR addresses the second point and thus allows for longer keepalive-intervals (e.g. 5 minutes) without intermittent network traffic.

I've tested this (with `keepalive-interval=300s`) for about two or three weeks now on both wifi and mobile network and have not noticed any spurious disconnects. My phone's battery life under normal usage has improved from a little more than a day to 3 days with this change, though, i.e. by a factor of 2-3!