### PR TITLE
Fix typos in Russian translation

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -7,7 +7,7 @@
     <string name="channel_subscriber_service_name">Сервис подписки</string>
     <string name="channel_notifications_min_name">Минимальный приоритет</string>
     <string name="channel_notifications_low_name">Низкий приоритет</string>
-    <string name="main_menu_notifications_disabled_forever">Уведомления заглушены</string>
+    <string name="main_menu_notifications_disabled_forever">Уведомления отключены</string>
     <string name="main_menu_notifications_enabled">Уведомления включены</string>
     <string name="main_menu_report_bug_title">Сообщить об ошибке</string>
     <string name="main_menu_settings_title">Настройки</string>
@@ -28,12 +28,12 @@
     <string name="detail_item_menu_copy_contents">Скопировать уведомление</string>
     <string name="detail_item_menu_copy_contents_copied">Уведомление скопировано</string>
     <string name="detail_item_saved_successfully">Сохранён как \"%1$s\" в папке \"Downloads\"</string>
-    <string name="detail_menu_notifications_disabled_until">Уведомления заглушены до %1$s</string>
+    <string name="detail_menu_notifications_disabled_until">Уведомления отключены до %1$s</string>
     <string name="detail_menu_enable_instant">Включить моментальную доставку</string>
     <string name="detail_menu_disable_instant">Выключить моментальную доставку</string>
     <string name="detail_menu_test">Отправить тестовое уведомление</string>
     <string name="detail_menu_copy_url">Скопировать URL-адрес темы</string>
-    <string name="detail_menu_clear">Отчистить все уведомления</string>
+    <string name="detail_menu_clear">Очистить все уведомления</string>
     <string name="detail_menu_settings">Настройки подписок</string>
     <string name="detail_menu_unsubscribe">Отписаться</string>
     <string name="detail_action_mode_menu_copy">Скопировать</string>
@@ -44,10 +44,10 @@
     <string name="detail_settings_title">Настройки подписок</string>
     <string name="share_title">Поделиться</string>
     <string name="share_menu_send">Поделиться</string>
-    <string name="notification_dialog_title">Заглушить уведомления</string>
+    <string name="notification_dialog_title">Отключить уведомления</string>
     <string name="settings_notifications_auto_download_100k">Если меньше 100 кб</string>
     <string name="settings_notifications_auto_delete_never">Никогда</string>
-    <string name="settings_notifications_auto_delete_three_days">Черед три дня</string>
+    <string name="settings_notifications_auto_delete_three_days">Через три дня</string>
     <string name="settings_notifications_auto_delete_one_day">Через один день</string>
     <string name="settings_notifications_auto_delete_one_week">Через неделю</string>
     <string name="settings_notifications_auto_delete_one_month">Через месяц</string>
@@ -76,7 +76,7 @@
     <string name="main_item_status_text_one">%1$d уведомление</string>
     <string name="main_item_status_reconnecting">повторное подключение …</string>
     <string name="main_no_subscriptions_text">Похоже, у вас ещё нет подписок.</string>
-    <string name="main_action_mode_delete_dialog_message">Отписаться от выбранных тем, и навсегда удалить все уведомления\?</string>
+    <string name="main_action_mode_delete_dialog_message">Отписаться от выбранных тем и навсегда удалить все уведомления\?</string>
     <string name="main_banner_websocket_button_remind_later">Спросить позже</string>
     <string name="add_dialog_title">Подписаться на тему</string>
     <string name="add_dialog_button_cancel">Отмена</string>
@@ -110,16 +110,16 @@
     <string name="detail_item_cannot_open">Вложение не открывается: %1$s</string>
     <string name="detail_item_cannot_open_not_found">Вложение не открывается: Возможно файл был удалёл, либо нет установленного приложения, способного открыть файл.</string>
     <string name="detail_menu_notifications_enabled">Уведомления включены</string>
-    <string name="detail_menu_notifications_disabled_forever">Уведомления заглушены</string>
+    <string name="detail_menu_notifications_disabled_forever">Уведомления отключены</string>
     <string name="notification_dialog_save">Сохранить</string>
-    <string name="notification_dialog_muted_until_toast_message">Уведомления заглушены до %1$s</string>
+    <string name="notification_dialog_muted_until_toast_message">Уведомления отключены до %1$s</string>
     <string name="notification_popup_action_open">Открыть</string>
     <string name="notification_popup_action_download">Скачать</string>
     <string name="notification_popup_file">%1$s
 \nФайл: %2$s</string>
     <string name="notification_dialog_cancel">Отмена</string>
     <string name="notification_dialog_enabled_toast_message">Уведомления разрешены</string>
-    <string name="notification_dialog_muted_forever_toast_message">Уведомления заглушены</string>
+    <string name="notification_dialog_muted_forever_toast_message">Уведомления отключены</string>
     <string name="notification_dialog_show_all">Показать все уведомления</string>
     <string name="notification_dialog_30min">30 минут</string>
     <string name="notification_dialog_8h">8 часов</string>
@@ -133,13 +133,13 @@
     <string name="settings_general_users_prefs_user_add_summary">Создать нового пользователя для нового сервера</string>
     <string name="settings_backup_restore_restore_title">Восстановить из файла</string>
     <string name="settings_general_users_prefs_user_add_title">Добавить нового пользователя</string>
-    <string name="main_menu_notifications_disabled_until">Уведомления заглушены до %1$s</string>
+    <string name="main_menu_notifications_disabled_until">Уведомления отключены до %1$s</string>
     <string name="refresh_message_error">Не получилось обновить %1$d подписок
 \n
 \n%2$s</string>
     <string name="refresh_message_error_one">Не получилось обновить подписку: %1$s</string>
     <string name="main_action_bar_title">Темы подписок</string>
-    <string name="main_how_to_intro">Нажмите + чтобы создать или подписаться на тему. Вы будете получать уведомления на вашем устройстве при отправке сообщений через PUT или POST-запросы.</string>
+    <string name="main_how_to_intro">Нажмите \"+\", чтобы создать или подписаться на тему. Вы будете получать уведомления на вашем устройстве при отправке сообщений через PUT или POST-запросы.</string>
     <string name="channel_subscriber_notification_instant_text">Подписан на темы с мгновенной доставкой</string>
     <string name="channel_subscriber_notification_instant_text_two">Подписан на две темы с мгновенной доставкой</string>
     <string name="channel_subscriber_notification_instant_text_one">Подписан на одну тему с мгновенной доставкой</string>
@@ -155,7 +155,7 @@
     <string name="add_dialog_error_connection_failed">Ошибка связи: %1$s</string>
     <string name="add_dialog_login_title">Требуется вход в аккаунт</string>
     <string name="add_dialog_login_description">Эта тема требует авторизации. Пожалуйста, введите имя пользователя и пароль.</string>
-    <string name="add_dialog_description_below">Темы не могут быть защищены паролем. Используйте название которое сложно угадать. После подписки вы сможете отправлять уведомления через PUT/POST.</string>
+    <string name="add_dialog_description_below">Темы не могут быть защищены паролем. Используйте название, которое сложно угадать. После подписки вы сможете отправлять уведомления через PUT/POST.</string>
     <string name="detail_test_message">Это тестовое уведомление от Android-приложения ntfy. Оно имеет уровень приоритета %1$d. Если вы отправите ещё одно, оно может выглядеть по-другому.</string>
     <string name="add_dialog_login_error_not_authorized">Вход не удался. Пользователь %1$s не авторизован.</string>
     <string name="detail_how_to_intro">Чтобы отправить уведомления на данную тему, просто отправьте PUT or POST на URL-адрес темы.</string>
@@ -197,10 +197,10 @@
 \nФайл: %2$s, скачан</string>
     <string name="notification_popup_file_download_failed">%1$s
 \nФайл: %2$s, не удалось скачать</string>
-    <string name="settings_notifications_muted_until_title">Заглушить уведомления</string>
+    <string name="settings_notifications_muted_until_title">Отключить уведомления</string>
     <string name="settings_notifications_muted_until_show_all">Показываются все уведомления</string>
-    <string name="settings_notifications_muted_until_forever">Уведомления заглушены пока не будут разрешены</string>
-    <string name="settings_notifications_muted_until_x">Уведомления заглушены до %1$s</string>
+    <string name="settings_notifications_muted_until_forever">Уведомления отключены, пока не будут разрешены</string>
+    <string name="settings_notifications_muted_until_x">Уведомления отключены до %1$s</string>
     <string name="settings_notifications_min_priority_title">Самый низкий приоритет</string>
     <string name="settings_notifications_min_priority_summary_any">Отображаются все уведомления</string>
     <string name="settings_notifications_min_priority_summary_x_or_higher">Показывать уведомления если приоритет %1$d(%2$s) или выше</string>
@@ -234,14 +234,14 @@
     <string name="settings_advanced_export_logs_entry_copy_original">Скопировать в буфер обмена</string>
     <string name="user_dialog_username_hint">Имя пользователя</string>
     <string name="user_dialog_button_save">Сохранить</string>
-    <string name="settings_general_default_base_url_message">Введите базовый URL вашего сервера, чтобы использовать ваш сервер по умолчанию при подписке на новые темы и/или публикацию в темы.</string>
+    <string name="settings_general_default_base_url_message">Введите базовый URL вашего сервера, чтобы использовать его по умолчанию при подписке на новые темы и/или публикацию в темы.</string>
     <string name="settings_general_users_title">Управление пользователями</string>
     <string name="settings_general_users_summary">Добавить/удалить пользователей из защищённых тем</string>
     <string name="settings_general_users_prefs_title">Пользователи</string>
     <string name="settings_general_users_prefs_user_not_used">Не использован в каких-либо темах</string>
     <string name="settings_general_users_prefs_user_used_by_one">Использован темой %1$s</string>
     <string name="settings_advanced_export_logs_copied_logs">Журналы скопированы в буфер обмена</string>
-    <string name="settings_advanced_export_logs_uploading">Загрузка журнала …</string>
+    <string name="settings_advanced_export_logs_uploading">Загрузка журнала…</string>
     <string name="settings_advanced_export_logs_copied_url">Журналы загружены, и URL скопирован</string>
     <string name="settings_advanced_export_logs_error_uploading">Не удалось загрузить журналы: %1$s</string>
     <string name="settings_advanced_export_logs_scrub_dialog_text">Следующие темы/доменные имена были заменены названиями фруктов, так что вы можете поделиться журналом без беспокойства:
@@ -249,14 +249,14 @@
 \n%1$s
 \n
 \nПароли скрыты, но не перечислены здесь.</string>
-    <string name="settings_advanced_export_logs_scrub_dialog_empty">Никакие темы/доменные имена не были заменены. Может быть у вас нет никаких подписок\?</string>
+    <string name="settings_advanced_export_logs_scrub_dialog_empty">Никакие темы/доменные имена не были заменены. Может быть, у вас нет никаких подписок\?</string>
     <string name="settings_advanced_export_logs_scrub_dialog_button_ok">ОК</string>
     <string name="settings_advanced_clear_logs_title">Очистить журналы</string>
     <string name="settings_advanced_clear_logs_summary">Удалить ранее записанные журналы, и начать сначала</string>
     <string name="settings_advanced_clear_logs_deleted_toast">Журналы удалены</string>
     <string name="settings_advanced_connection_protocol_title">Протокол соединения</string>
     <string name="settings_advanced_connection_protocol_summary_jsonhttp">Использовать JSON-поток через HTTP чтобы подключаться к серверу. Это надежный метод, но он может потреблять больше энергии.</string>
-    <string name="settings_advanced_connection_protocol_summary_ws">Использовать WebSockets для подключения к серверу. Это рекомендуемый метод, но может потребовать доплонительной настройки прокси-сервера.</string>
+    <string name="settings_advanced_connection_protocol_summary_ws">Использовать WebSockets для подключения к серверу. Это рекомендуемый метод, но может потребовать дополнительной настройки прокси-сервера.</string>
     <string name="settings_advanced_connection_protocol_entry_jsonhttp">JSON поток поверх HTTP</string>
     <string name="settings_advanced_connection_protocol_entry_ws">WebSockets</string>
     <string name="settings_about_header">О программе</string>
@@ -292,12 +292,12 @@
     <string name="settings_advanced_record_logs_summary_disabled">Включить журналирование, чтобы вы могли поделиться журналами позже для диагностики неполадок.</string>
     <string name="settings_advanced_export_logs_title">Скопировать/загрузить журналы</string>
     <string name="settings_advanced_export_logs_entry_copy_scrubbed">Скопировать в буфер обмена (с цензурой)</string>
-    <string name="settings_advanced_export_logs_entry_upload_original">Загрузить, и скопировать ссылку</string>
-    <string name="settings_advanced_export_logs_entry_upload_scrubbed">Загрузить, и скопировать ссылку (с цензурой)</string>
+    <string name="settings_advanced_export_logs_entry_upload_original">Загрузить и скопировать ссылку</string>
+    <string name="settings_advanced_export_logs_entry_upload_scrubbed">Загрузить и скопировать ссылку (с цензурой)</string>
     <string name="user_dialog_description_edit">Вы можете изменить имя или пароль выбранного пользователя, или удалить его.</string>
     <string name="user_dialog_base_url_hint">Базовый URL службы</string>
     <string name="user_dialog_password_hint_add">Пароль</string>
-    <string name="user_dialog_password_hint_edit">Пароль (не изменится если оставить пустым)</string>
+    <string name="user_dialog_password_hint_edit">Пароль (не изменится, если оставить пустым)</string>
     <string name="user_dialog_button_add">Добавить пользователя</string>
     <string name="user_dialog_button_cancel">Отмена</string>
     <string name="user_dialog_button_delete">Удалить пользователя</string>
@@ -307,20 +307,20 @@
     <string name="channel_subscriber_notification_noinstant_text_five">Подписан на пять тем</string>
     <string name="channel_subscriber_notification_noinstant_text_six">Подписан на шесть тем</string>
     <string name="main_banner_websocket_button_enable_now">Включить сейчас</string>
-    <string name="detail_settings_notifications_instant_summary_on">Уведомления доставляются сразу. Требует forground сервис и потребляет больше энергии.</string>
-    <string name="settings_notifications_insistent_max_priority_summary_enabled">Уведомления с наивысшим приоритетом будут требовать внимания пока не будут прочтены</string>
+    <string name="detail_settings_notifications_instant_summary_on">Уведомления доставляются сразу. Требует foreground сервис и потребляет больше энергии.</string>
+    <string name="settings_notifications_insistent_max_priority_summary_enabled">Уведомления с наивысшим приоритетом будут требовать внимания, пока не будут прочитаны</string>
     <string name="channel_notifications_group_default_name">По умолчанию</string>
-    <string name="detail_item_cannot_open_apk">Установка приложений через уведомления больше не поддерживается. Скачайте приложение через браузер. Подробности смотрите в отчете ntfy #531.</string>
+    <string name="detail_item_cannot_open_apk">Установка приложений через уведомления больше не поддерживается. Скачайте приложение через браузер. Подробности смотрите в отчёте ntfy #531.</string>
     <string name="detail_settings_appearance_icon_set_title">Иконка подписки</string>
     <string name="detail_settings_appearance_icon_set_summary">Использовать иконку для отображения в уведомлениях</string>
     <string name="main_menu_donate_title">Пожертвовать 💸</string>
-    <string name="settings_notifications_insistent_max_priority_summary_disabled">Уведомления с наивысшим приориетом будут давать о себе знать только один раз</string>
-    <string name="detail_settings_notifications_instant_summary_off">Уведомления будут доставляться с помощью Firebase. Могут быть задержки с доставкой, но потребляет меньше энергии.</string>
+    <string name="settings_notifications_insistent_max_priority_summary_disabled">Уведомления с наивысшим приоритетом будут давать о себе знать только один раз</string>
+    <string name="detail_settings_notifications_instant_summary_off">Уведомления будут доставляться с помощью Firebase. Могут быть задержки с доставкой, но потребляется меньше энергии.</string>
     <string name="add_dialog_base_urls_dropdown_clear">Очистить URL-адрес сервера</string>
     <string name="detail_settings_appearance_header">Внешний вид</string>
     <string name="detail_settings_appearance_icon_error_saving">Невозможно сохранить иконку: %1$s</string>
     <string name="detail_settings_appearance_display_name_title">Псевдоним</string>
-    <string name="detail_settings_global_setting_suffix">испольует глобальное значение</string>
+    <string name="detail_settings_global_setting_suffix">использует глобальное значение</string>
     <string name="detail_settings_appearance_display_name_message">Выставить произвольный псевдоним для этой подписки. Оставьте пустым чтобы использовать значение по умолчанию (%1$s).</string>
     <string name="detail_settings_appearance_display_name_default_summary">%1$s (по умолчанию)</string>
     <string name="detail_settings_about_topic_url_copied_to_clipboard_message">Скопирован в буфер обмена</string>
@@ -336,7 +336,7 @@
     <string name="detail_settings_appearance_icon_remove_summary">Иконка используемая в уведомлениях от этой темы</string>
     <string name="detail_settings_global_setting_title">Использовать глобальное значение</string>
     <string name="detail_settings_notifications_insistent_max_priority_list_item_enabled">Продолжать уведомлять</string>
-    <string name="main_banner_websocket_text">Мы рекомендуем использовать WebSockets для подключения к Вашему серверу; это может продлить время работы от батареи, но может потребовать <a href="https://ntfy.sh/docs/config/#nginxapache2caddy">дополнительной настройки прокси-сервера</a>. Эта опция может быть включена или выключена в Настройках.</string>
+    <string name="main_banner_websocket_text">Мы рекомендуем использовать WebSockets для подключения к Вашему серверу; это продлит время работы от батареи, но может потребовать <a href="https://ntfy.sh/docs/config/#nginxapache2caddy">дополнительной настройки прокси-сервера</a>. Эта опция может быть включена или выключена в Настройках.</string>
     <string name="detail_settings_appearance_icon_remove_title">Иконка подписки (коснитесь, чтобы удалить)</string>
     <string name="add_dialog_base_urls_dropdown_choose">Выберите URL-адрес сервера</string>
     <string name="detail_settings_notifications_open_channels_summary">Игнорирование режима \"не беспокоить\", звуки и прочее.</string>


### PR DESCRIPTION
Typos, punctuation, minor stylistic fixes.
Also, "заглушить" and its derivatives are replaced with "отключить", as it's the term for notification used across all the Android.