### PR TITLE
add: header auth

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/db/Repository.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Repository.kt
@@ -11,6 +11,8 @@ import io.heckel.ntfy.util.Log
 import io.heckel.ntfy.util.validUrl
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 
 class Repository(private val sharedPrefs: SharedPreferences, private val database: Database) {
     private val subscriptionDao = database.subscriptionDao()
@@ -88,35 +90,32 @@ class Repository(private val sharedPrefs: SharedPreferences, private val databas
         subscriptionDao.remove(subscriptionId)
     }
 
-    fun getCustomHeader1(): String {
-        return sharedPrefs.getString(SHARED_PREFS_CUSTOM_HEADER_1, "") ?: ""
-    }
-
-    fun setCustomHeader1(value: String) {
-        if (value.isEmpty()) {
-            sharedPrefs.edit()
-                .remove(SHARED_PREFS_CUSTOM_HEADER_1)
-                .apply()
+    fun getCustomHeaders(): Map<String, String> {
+        val json = sharedPrefs.getString(SHARED_PREFS_CUSTOM_HEADERS, null)
+        return if (json != null) {
+            try {
+                val type = object : TypeToken<Map<String, String>>() {}.type
+                Gson().fromJson(json, type) ?: emptyMap()
+            } catch (e: Exception) {
+                Log.w("Repository", "Failed to parse custom headers", e)
+                emptyMap()
+            }
         } else {
-            sharedPrefs.edit()
-                .putString(SHARED_PREFS_CUSTOM_HEADER_1, value)
-                .apply()
+            emptyMap()
         }
     }
 
-    fun getCustomHeader2(): String {
-        return sharedPrefs.getString(SHARED_PREFS_CUSTOM_HEADER_2, "") ?: ""
-    }
-
-    fun setCustomHeader2(value: String) {
-        if (value.isEmpty()) {
-            sharedPrefs.edit()
-                .remove(SHARED_PREFS_CUSTOM_HEADER_2)
-                .apply()
+    fun setCustomHeaders(headers: Map<String, String>) {
+        val json = if (headers.isEmpty()) {
+            null
         } else {
-            sharedPrefs.edit()
-                .putString(SHARED_PREFS_CUSTOM_HEADER_2, value)
-                .apply()
+            Gson().toJson(headers)
+        }
+
+        if (json == null) {
+            sharedPrefs.edit().remove(SHARED_PREFS_CUSTOM_HEADERS).apply()
+        } else {
+            sharedPrefs.edit().putString(SHARED_PREFS_CUSTOM_HEADERS, json).apply()
         }
     }
 
@@ -518,8 +517,6 @@ class Repository(private val sharedPrefs: SharedPreferences, private val databas
     }
 
     companion object {
-        const val SHARED_PREFS_CUSTOM_HEADER_1 = "CustomHeader1"
-        const val SHARED_PREFS_CUSTOM_HEADER_2 = "CustomHeader2"
         const val SHARED_PREFS_ID = "MainPreferences"
         const val SHARED_PREFS_POLL_WORKER_VERSION = "PollWorkerVersion"
         const val SHARED_PREFS_DELETE_WORKER_VERSION = "DeleteWorkerVersion"
@@ -540,6 +537,7 @@ class Repository(private val sharedPrefs: SharedPreferences, private val databas
         const val SHARED_PREFS_UNIFIED_PUSH_BASE_URL = "UnifiedPushBaseURL" // Legacy key required for migration to DefaultBaseURL
         const val SHARED_PREFS_DEFAULT_BASE_URL = "DefaultBaseURL"
         const val SHARED_PREFS_LAST_TOPICS = "LastTopics"
+        const val SHARED_PREFS_CUSTOM_HEADERS = "CustomHeaders"
 
         private const val LAST_TOPICS_COUNT = 3
 

--- a/app/src/main/java/io/heckel/ntfy/db/Repository.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Repository.kt
@@ -88,6 +88,38 @@ class Repository(private val sharedPrefs: SharedPreferences, private val databas
         subscriptionDao.remove(subscriptionId)
     }
 
+    fun getCustomHeader1(): String {
+        return sharedPrefs.getString(SHARED_PREFS_CUSTOM_HEADER_1, "") ?: ""
+    }
+
+    fun setCustomHeader1(value: String) {
+        if (value.isEmpty()) {
+            sharedPrefs.edit()
+                .remove(SHARED_PREFS_CUSTOM_HEADER_1)
+                .apply()
+        } else {
+            sharedPrefs.edit()
+                .putString(SHARED_PREFS_CUSTOM_HEADER_1, value)
+                .apply()
+        }
+    }
+
+    fun getCustomHeader2(): String {
+        return sharedPrefs.getString(SHARED_PREFS_CUSTOM_HEADER_2, "") ?: ""
+    }
+
+    fun setCustomHeader2(value: String) {
+        if (value.isEmpty()) {
+            sharedPrefs.edit()
+                .remove(SHARED_PREFS_CUSTOM_HEADER_2)
+                .apply()
+        } else {
+            sharedPrefs.edit()
+                .putString(SHARED_PREFS_CUSTOM_HEADER_2, value)
+                .apply()
+        }
+    }
+
     suspend fun getNotifications(): List<Notification> {
         return notificationDao.list()
     }
@@ -486,6 +518,8 @@ class Repository(private val sharedPrefs: SharedPreferences, private val databas
     }
 
     companion object {
+        const val SHARED_PREFS_CUSTOM_HEADER_1 = "CustomHeader1"
+        const val SHARED_PREFS_CUSTOM_HEADER_2 = "CustomHeader2"
         const val SHARED_PREFS_ID = "MainPreferences"
         const val SHARED_PREFS_POLL_WORKER_VERSION = "PollWorkerVersion"
         const val SHARED_PREFS_DELETE_WORKER_VERSION = "DeleteWorkerVersion"

--- a/app/src/main/java/io/heckel/ntfy/msg/ApiService.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/ApiService.kt
@@ -182,9 +182,17 @@ class ApiService {
             val builder = Request.Builder()
                 .url(url)
                 .addHeader("User-Agent", USER_AGENT)
+
+            // Add existing auth header
             if (user != null) {
                 builder.addHeader("Authorization", Credentials.basic(user.username, user.password, UTF_8))
             }
+
+            // Add custom headers
+            CustomHeaderConfig.getCustomHeaders().forEach { (name, value) ->
+                builder.addHeader(name, value)
+            }
+
             return builder
         }
     }

--- a/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
@@ -10,6 +10,7 @@ import io.heckel.ntfy.msg.NotificationParser
 import io.heckel.ntfy.util.Log
 import io.heckel.ntfy.util.topicShortUrl
 import io.heckel.ntfy.util.topicUrlWs
+import io.heckel.ntfy.util.CustomHeaderConfig
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import okhttp3.WebSocket
@@ -78,7 +79,16 @@ class WsConnection(
         val sinceId = since.get()
         val sinceVal = sinceId ?: "all"
         val urlWithSince = topicUrlWs(baseUrl, topicsStr, sinceVal)
-        val request = requestBuilder(urlWithSince, user).build()
+
+        // Build request with custom headers
+        val requestBuilder = requestBuilder(urlWithSince, user)
+
+        // Add custom headers for WebSocket
+        CustomHeaderConfig.getCustomHeaders().forEach { (name, value) ->
+            requestBuilder.addHeader(name, value)
+        }
+
+        val request = requestBuilder.build()
         Log.d(TAG, "$shortUrl (gid=$globalId): Opening $urlWithSince with listener ID $nextListenerId ...")
         webSocket = client.newWebSocket(request, Listener(nextListenerId))
     }

--- a/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
@@ -5,12 +5,11 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import io.heckel.ntfy.db.*
-import io.heckel.ntfy.msg.ApiService.Companion.requestBuilder
+import io.heckel.ntfy.msg.ApiService
 import io.heckel.ntfy.msg.NotificationParser
 import io.heckel.ntfy.util.Log
 import io.heckel.ntfy.util.topicShortUrl
 import io.heckel.ntfy.util.topicUrlWs
-import io.heckel.ntfy.util.CustomHeaderConfig
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import okhttp3.WebSocket
@@ -81,17 +80,13 @@ class WsConnection(
         val urlWithSince = topicUrlWs(baseUrl, topicsStr, sinceVal)
 
         // Build request with custom headers
-        val requestBuilder = requestBuilder(urlWithSince, user)
-
-        // Add custom headers for WebSocket
-        CustomHeaderConfig.getCustomHeaders().forEach { (name, value) ->
-            requestBuilder.addHeader(name, value)
-        }
-
+        val requestBuilder = ApiService.requestBuilder(urlWithSince, user, repository)
         val request = requestBuilder.build()
+
         Log.d(TAG, "$shortUrl (gid=$globalId): Opening $urlWithSince with listener ID $nextListenerId ...")
         webSocket = client.newWebSocket(request, Listener(nextListenerId))
     }
+
 
     @Synchronized
     override fun close() {

--- a/app/src/main/java/io/heckel/ntfy/ui/CustomHeadersFragment.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/CustomHeadersFragment.kt
@@ -51,13 +51,7 @@ class CustomHeadersFragment : PreferenceFragmentCompat() {
         val preference = Preference(requireContext())
         preference.key = "header_$name"
         preference.title = name
-        preference.summary = if (name.contains("secret", ignoreCase = true) ||
-            name.contains("password", ignoreCase = true) ||
-            name.contains("token", ignoreCase = true)) {
-            "••••••••" // Hide sensitive values
-        } else {
-            value
-        }
+        preference.summary = "••••••••" // Always hide all values
 
         preference.onPreferenceClickListener = Preference.OnPreferenceClickListener {
             showEditHeaderDialog(name, value)

--- a/app/src/main/java/io/heckel/ntfy/ui/CustomHeadersFragment.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/CustomHeadersFragment.kt
@@ -1,0 +1,181 @@
+package io.heckel.ntfy.ui
+
+import android.app.AlertDialog
+import android.os.Bundle
+import android.view.View
+import android.widget.EditText
+import android.widget.LinearLayout
+import androidx.lifecycle.lifecycleScope
+import androidx.preference.*
+import io.heckel.ntfy.R
+import io.heckel.ntfy.db.Repository
+import io.heckel.ntfy.service.SubscriberServiceManager
+import io.heckel.ntfy.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class CustomHeadersFragment : PreferenceFragmentCompat() {
+    private lateinit var repository: Repository
+    private lateinit var serviceManager: SubscriberServiceManager
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.custom_headers_preferences, rootKey)
+
+        repository = Repository.getInstance(requireActivity())
+        serviceManager = SubscriberServiceManager(requireActivity())
+
+        loadCustomHeaders()
+
+        // Add "Add Header" button
+        val addHeaderPref: Preference? = findPreference("add_custom_header")
+        addHeaderPref?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+            showAddHeaderDialog()
+            true
+        }
+    }
+
+    private fun loadCustomHeaders() {
+        // Clear existing headers (except the add button)
+        val addHeaderPref = findPreference<Preference>("add_custom_header")
+        preferenceScreen.removeAll()
+        addHeaderPref?.let { preferenceScreen.addPreference(it) }
+
+        // Add current headers
+        val headers = repository.getCustomHeaders()
+        headers.forEach { (name, value) ->
+            addHeaderPreference(name, value)
+        }
+    }
+
+    private fun addHeaderPreference(name: String, value: String) {
+        val preference = Preference(requireContext())
+        preference.key = "header_$name"
+        preference.title = name
+        preference.summary = if (name.contains("secret", ignoreCase = true) ||
+            name.contains("password", ignoreCase = true) ||
+            name.contains("token", ignoreCase = true)) {
+            "••••••••" // Hide sensitive values
+        } else {
+            value
+        }
+
+        preference.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+            showEditHeaderDialog(name, value)
+            true
+        }
+
+        // Insert before the "Add Header" button
+        val addHeaderIndex = preferenceScreen.preferenceCount - 1
+        preferenceScreen.addPreference(preference)
+        if (addHeaderIndex >= 0) {
+            preference.order = addHeaderIndex
+        }
+    }
+
+    private fun showAddHeaderDialog() {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_custom_header, null)
+        val nameEdit = dialogView.findViewById<EditText>(R.id.header_name)
+        val valueEdit = dialogView.findViewById<EditText>(R.id.header_value)
+
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.custom_headers_add_title)
+            .setView(dialogView)
+            .setPositiveButton(R.string.custom_headers_add) { _, _ ->
+                val name = nameEdit.text.toString().trim()
+                val value = valueEdit.text.toString().trim()
+
+                if (name.isNotEmpty() && value.isNotEmpty()) {
+                    if (isValidHeaderName(name)) {
+                        addHeader(name, value)
+                    } else {
+                        showErrorDialog(getString(R.string.custom_headers_invalid_name))
+                    }
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun showEditHeaderDialog(currentName: String, currentValue: String) {
+        val dialogView = layoutInflater.inflate(R.layout.dialog_custom_header, null)
+        val nameEdit = dialogView.findViewById<EditText>(R.id.header_name)
+        val valueEdit = dialogView.findViewById<EditText>(R.id.header_value)
+
+        nameEdit.setText(currentName)
+        valueEdit.setText(currentValue)
+
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.custom_headers_edit_title)
+            .setView(dialogView)
+            .setPositiveButton(R.string.custom_headers_save) { _, _ ->
+                val name = nameEdit.text.toString().trim()
+                val value = valueEdit.text.toString().trim()
+
+                if (name.isNotEmpty() && value.isNotEmpty()) {
+                    if (isValidHeaderName(name)) {
+                        updateHeader(currentName, name, value)
+                    } else {
+                        showErrorDialog(getString(R.string.custom_headers_invalid_name))
+                    }
+                }
+            }
+            .setNeutralButton(R.string.custom_headers_delete) { _, _ ->
+                showDeleteConfirmDialog(currentName)
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun showDeleteConfirmDialog(name: String) {
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.custom_headers_delete_title)
+            .setMessage(getString(R.string.custom_headers_delete_message, name))
+            .setPositiveButton(R.string.custom_headers_delete) { _, _ ->
+                deleteHeader(name)
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun showErrorDialog(message: String) {
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.custom_headers_error_title)
+            .setMessage(message)
+            .setPositiveButton(android.R.string.ok, null)
+            .show()
+    }
+
+    private fun addHeader(name: String, value: String) {
+        val headers = repository.getCustomHeaders().toMutableMap()
+        headers[name] = value
+        repository.setCustomHeaders(headers)
+        loadCustomHeaders()
+        restartService()
+    }
+
+    private fun updateHeader(oldName: String, newName: String, value: String) {
+        val headers = repository.getCustomHeaders().toMutableMap()
+        headers.remove(oldName)
+        headers[newName] = value
+        repository.setCustomHeaders(headers)
+        loadCustomHeaders()
+        restartService()
+    }
+
+    private fun deleteHeader(name: String) {
+        val headers = repository.getCustomHeaders().toMutableMap()
+        headers.remove(name)
+        repository.setCustomHeaders(headers)
+        loadCustomHeaders()
+        restartService()
+    }
+
+    private fun isValidHeaderName(name: String): Boolean {
+        // Basic header name validation according to RFC 7230
+        return name.matches(Regex("^[!#$%&'*+\\-.0-9A-Z^_`a-z|~]+$"))
+    }
+
+    private fun restartService() {
+        serviceManager.restart()
+    }
+}

--- a/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
@@ -353,64 +353,6 @@ class SettingsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPrefere
                 }
             }
 
-            val customHeader1PrefId = context?.getString(R.string.settings_advanced_custom_header_1_key) ?: return
-            val customHeader1: EditTextPreference? = findPreference(customHeader1PrefId)
-            customHeader1?.text = repository.getCustomHeader1()
-            customHeader1?.preferenceDataStore = object : PreferenceDataStore() {
-                override fun putString(key: String, value: String?) {
-                    val headerValue = value ?: ""
-                    repository.setCustomHeader1(headerValue)
-                    serviceManager.restart() // Restart service to apply new headers
-                }
-                override fun getString(key: String, defValue: String?): String? {
-                    return repository.getCustomHeader1()
-                }
-            }
-            customHeader1?.setOnBindEditTextListener { editText ->
-                editText.addTextChangedListener(AfterChangedTextWatcher {
-                    val okayButton: Button = editText.rootView.findViewById(android.R.id.button1)
-                    // Always enable - empty values are allowed to clear the header
-                    okayButton.isEnabled = true
-                })
-            }
-            customHeader1?.summaryProvider = Preference.SummaryProvider<EditTextPreference> { pref ->
-                if (TextUtils.isEmpty(pref.text)) {
-                    getString(R.string.settings_advanced_custom_header_1_summary_empty)
-                } else {
-                    getString(R.string.settings_advanced_custom_header_1_summary_set)
-                }
-            }
-
-            // Custom Header 2 (CF-Access-Client-Secret)
-            val customHeader2PrefId = context?.getString(R.string.settings_advanced_custom_header_2_key) ?: return
-            val customHeader2: EditTextPreference? = findPreference(customHeader2PrefId)
-            customHeader2?.text = repository.getCustomHeader2()
-            customHeader2?.preferenceDataStore = object : PreferenceDataStore() {
-                override fun putString(key: String, value: String?) {
-                    val headerValue = value ?: ""
-                    repository.setCustomHeader2(headerValue)
-                    serviceManager.restart() // Restart service to apply new headers
-                }
-                override fun getString(key: String, defValue: String?): String? {
-                    return repository.getCustomHeader2()
-                }
-            }
-            customHeader2?.setOnBindEditTextListener { editText ->
-                // Make this a password field for security
-                editText.inputType = android.text.InputType.TYPE_CLASS_TEXT or android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD
-                editText.addTextChangedListener(AfterChangedTextWatcher {
-                    val okayButton: Button = editText.rootView.findViewById(android.R.id.button1)
-                    okayButton.isEnabled = true
-                })
-            }
-            customHeader2?.summaryProvider = Preference.SummaryProvider<EditTextPreference> { pref ->
-                if (TextUtils.isEmpty(pref.text)) {
-                    getString(R.string.settings_advanced_custom_header_2_summary_empty)
-                } else {
-                    getString(R.string.settings_advanced_custom_header_2_summary_set)
-                }
-            }
-
             // Broadcast enabled
             val broadcastEnabledPrefId = context?.getString(R.string.settings_advanced_broadcast_key) ?: return
             val broadcastEnabled: SwitchPreference? = findPreference(broadcastEnabledPrefId)

--- a/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
@@ -353,6 +353,64 @@ class SettingsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPrefere
                 }
             }
 
+            val customHeader1PrefId = context?.getString(R.string.settings_advanced_custom_header_1_key) ?: return
+            val customHeader1: EditTextPreference? = findPreference(customHeader1PrefId)
+            customHeader1?.text = repository.getCustomHeader1()
+            customHeader1?.preferenceDataStore = object : PreferenceDataStore() {
+                override fun putString(key: String, value: String?) {
+                    val headerValue = value ?: ""
+                    repository.setCustomHeader1(headerValue)
+                    serviceManager.restart() // Restart service to apply new headers
+                }
+                override fun getString(key: String, defValue: String?): String? {
+                    return repository.getCustomHeader1()
+                }
+            }
+            customHeader1?.setOnBindEditTextListener { editText ->
+                editText.addTextChangedListener(AfterChangedTextWatcher {
+                    val okayButton: Button = editText.rootView.findViewById(android.R.id.button1)
+                    // Always enable - empty values are allowed to clear the header
+                    okayButton.isEnabled = true
+                })
+            }
+            customHeader1?.summaryProvider = Preference.SummaryProvider<EditTextPreference> { pref ->
+                if (TextUtils.isEmpty(pref.text)) {
+                    getString(R.string.settings_advanced_custom_header_1_summary_empty)
+                } else {
+                    getString(R.string.settings_advanced_custom_header_1_summary_set)
+                }
+            }
+
+            // Custom Header 2 (CF-Access-Client-Secret)
+            val customHeader2PrefId = context?.getString(R.string.settings_advanced_custom_header_2_key) ?: return
+            val customHeader2: EditTextPreference? = findPreference(customHeader2PrefId)
+            customHeader2?.text = repository.getCustomHeader2()
+            customHeader2?.preferenceDataStore = object : PreferenceDataStore() {
+                override fun putString(key: String, value: String?) {
+                    val headerValue = value ?: ""
+                    repository.setCustomHeader2(headerValue)
+                    serviceManager.restart() // Restart service to apply new headers
+                }
+                override fun getString(key: String, defValue: String?): String? {
+                    return repository.getCustomHeader2()
+                }
+            }
+            customHeader2?.setOnBindEditTextListener { editText ->
+                // Make this a password field for security
+                editText.inputType = android.text.InputType.TYPE_CLASS_TEXT or android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD
+                editText.addTextChangedListener(AfterChangedTextWatcher {
+                    val okayButton: Button = editText.rootView.findViewById(android.R.id.button1)
+                    okayButton.isEnabled = true
+                })
+            }
+            customHeader2?.summaryProvider = Preference.SummaryProvider<EditTextPreference> { pref ->
+                if (TextUtils.isEmpty(pref.text)) {
+                    getString(R.string.settings_advanced_custom_header_2_summary_empty)
+                } else {
+                    getString(R.string.settings_advanced_custom_header_2_summary_set)
+                }
+            }
+
             // Broadcast enabled
             val broadcastEnabledPrefId = context?.getString(R.string.settings_advanced_broadcast_key) ?: return
             val broadcastEnabled: SwitchPreference? = findPreference(broadcastEnabledPrefId)

--- a/app/src/main/java/io/heckel/ntfy/util/CustomHeaderConfig.kt
+++ b/app/src/main/java/io/heckel/ntfy/util/CustomHeaderConfig.kt
@@ -1,24 +1,26 @@
 package io.heckel.ntfy.util
 
+import io.heckel.ntfy.db.Repository
+
 object CustomHeaderConfig {
-    // Set these to your Cloudflare Zero Trust values
+    // Default header names - users can configure the values in settings
     const val CUSTOM_HEADER_1_NAME = "CF-Access-Client-Id"
-    const val CUSTOM_HEADER_1_VALUE = "your-client-id-here"
-
     const val CUSTOM_HEADER_2_NAME = "CF-Access-Client-Secret"
-    const val CUSTOM_HEADER_2_VALUE = "your-client-secret-here"
 
-    // Enable/disable custom headers easily
-    const val CUSTOM_HEADERS_ENABLED = true
+    fun getCustomHeaders(repository: Repository): Map<String, String> {
+        val headers = mutableMapOf<String, String>()
 
-    fun getCustomHeaders(): Map<String, String> {
-        return if (CUSTOM_HEADERS_ENABLED) {
-            mapOf(
-                CUSTOM_HEADER_1_NAME to CUSTOM_HEADER_1_VALUE,
-                CUSTOM_HEADER_2_NAME to CUSTOM_HEADER_2_VALUE
-            )
-        } else {
-            emptyMap()
+        val clientId = repository.getCustomHeader1()
+        val clientSecret = repository.getCustomHeader2()
+
+        if (clientId.isNotEmpty()) {
+            headers[CUSTOM_HEADER_1_NAME] = clientId
         }
+
+        if (clientSecret.isNotEmpty()) {
+            headers[CUSTOM_HEADER_2_NAME] = clientSecret
+        }
+
+        return headers
     }
 }

--- a/app/src/main/java/io/heckel/ntfy/util/CustomHeaderConfig.kt
+++ b/app/src/main/java/io/heckel/ntfy/util/CustomHeaderConfig.kt
@@ -1,26 +1,24 @@
 package io.heckel.ntfy.util
 
 import io.heckel.ntfy.db.Repository
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 
 object CustomHeaderConfig {
-    // Default header names - users can configure the values in settings
-    const val CUSTOM_HEADER_1_NAME = "CF-Access-Client-Id"
-    const val CUSTOM_HEADER_2_NAME = "CF-Access-Client-Secret"
 
     fun getCustomHeaders(repository: Repository): Map<String, String> {
-        val headers = mutableMapOf<String, String>()
+        return repository.getCustomHeaders()
+    }
 
-        val clientId = repository.getCustomHeader1()
-        val clientSecret = repository.getCustomHeader2()
+    fun addCustomHeader(repository: Repository, name: String, value: String) {
+        val headers = repository.getCustomHeaders().toMutableMap()
+        headers[name] = value
+        repository.setCustomHeaders(headers)
+    }
 
-        if (clientId.isNotEmpty()) {
-            headers[CUSTOM_HEADER_1_NAME] = clientId
-        }
-
-        if (clientSecret.isNotEmpty()) {
-            headers[CUSTOM_HEADER_2_NAME] = clientSecret
-        }
-
-        return headers
+    fun removeCustomHeader(repository: Repository, name: String) {
+        val headers = repository.getCustomHeaders().toMutableMap()
+        headers.remove(name)
+        repository.setCustomHeaders(headers)
     }
 }

--- a/app/src/main/java/io/heckel/ntfy/util/CustomHeaderConfig.kt
+++ b/app/src/main/java/io/heckel/ntfy/util/CustomHeaderConfig.kt
@@ -1,0 +1,24 @@
+package io.heckel.ntfy.util
+
+object CustomHeaderConfig {
+    // Set these to your Cloudflare Zero Trust values
+    const val CUSTOM_HEADER_1_NAME = "CF-Access-Client-Id"
+    const val CUSTOM_HEADER_1_VALUE = "your-client-id-here"
+
+    const val CUSTOM_HEADER_2_NAME = "CF-Access-Client-Secret"
+    const val CUSTOM_HEADER_2_VALUE = "your-client-secret-here"
+
+    // Enable/disable custom headers easily
+    const val CUSTOM_HEADERS_ENABLED = true
+
+    fun getCustomHeaders(): Map<String, String> {
+        return if (CUSTOM_HEADERS_ENABLED) {
+            mapOf(
+                CUSTOM_HEADER_1_NAME to CUSTOM_HEADER_1_VALUE,
+                CUSTOM_HEADER_2_NAME to CUSTOM_HEADER_2_VALUE
+            )
+        } else {
+            emptyMap()
+        }
+    }
+}

--- a/app/src/main/res/layout/dialog_custom_header.xml
+++ b/app/src/main/res/layout/dialog_custom_header.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/custom_headers_name_hint">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/header_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text"
+            android:singleLine="true" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/custom_headers_value_hint">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/header_value"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text"
+            android:singleLine="true" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -356,16 +356,9 @@
     <string name="settings_advanced_exact_alarms_title">Exact alarms</string>
     <string name="settings_advanced_exact_alarms_true">ntfy can schedule exact alarms. Exact alarms are required to reconnect WebSockets in the background. Click to revoke the permission.</string>
     <string name="settings_advanced_exact_alarms_false">ntfy cannot schedule exact alarms. Exact alarms are required to reconnect WebSockets in the background. Click to grant the permission.</string>
-    <string name="settings_advanced_custom_header_1_key">CustomHeader1</string>
-    <string name="settings_advanced_custom_header_1_title">CF-Access-Client-Id</string>
-    <string name="settings_advanced_custom_header_1_summary_empty">Not set (Cloudflare Zero Trust disabled)</string>
-    <string name="settings_advanced_custom_header_1_summary_set">Set (Cloudflare Zero Trust enabled)</string>
-    <string name="settings_advanced_custom_header_1_description">Enter your Cloudflare Access Client ID for Zero Trust authentication</string>
-    <string name="settings_advanced_custom_header_2_key">CustomHeader2</string>
-    <string name="settings_advanced_custom_header_2_title">CF-Access-Client-Secret</string>
-    <string name="settings_advanced_custom_header_2_summary_empty">Not set (Cloudflare Zero Trust disabled)</string>
-    <string name="settings_advanced_custom_header_2_summary_set">Set (Cloudflare Zero Trust enabled)</string>
-    <string name="settings_advanced_custom_header_2_description">Enter your Cloudflare Access Client Secret for Zero Trust authentication</string>
+    <string name="settings_advanced_custom_headers_key">CustomHeaders</string>
+    <string name="settings_advanced_custom_headers_title">Custom Headers</string>
+    <string name="settings_advanced_custom_headers_summary">Add custom HTTP headers to all requests</string>
     <string name="settings_about_header">About</string>
     <string name="settings_about_version_title">Version</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>
@@ -410,4 +403,19 @@
     <string name="user_dialog_button_cancel">Cancel</string>
     <string name="user_dialog_button_delete">Delete user</string>
     <string name="user_dialog_button_save">Save</string>
+
+    <!-- Custom Headers dialog  -->
+    <string name="custom_headers_add_header">Add Header</string>
+    <string name="custom_headers_add_summary">Add a new custom HTTP header</string>
+    <string name="custom_headers_add_title">Add Custom Header</string>
+    <string name="custom_headers_edit_title">Edit Custom Header</string>
+    <string name="custom_headers_delete_title">Delete Header</string>
+    <string name="custom_headers_delete_message">Are you sure you want to delete the header "%1$s"?</string>
+    <string name="custom_headers_add">Add</string>
+    <string name="custom_headers_save">Save</string>
+    <string name="custom_headers_delete">Delete</string>
+    <string name="custom_headers_error_title">Invalid Header</string>
+    <string name="custom_headers_invalid_name">Header name contains invalid characters</string>
+    <string name="custom_headers_name_hint">Header name (e.g., CF-Access-Client-Id)</string>
+    <string name="custom_headers_value_hint">Header value</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -356,6 +356,16 @@
     <string name="settings_advanced_exact_alarms_title">Exact alarms</string>
     <string name="settings_advanced_exact_alarms_true">ntfy can schedule exact alarms. Exact alarms are required to reconnect WebSockets in the background. Click to revoke the permission.</string>
     <string name="settings_advanced_exact_alarms_false">ntfy cannot schedule exact alarms. Exact alarms are required to reconnect WebSockets in the background. Click to grant the permission.</string>
+    <string name="settings_advanced_custom_header_1_key">CustomHeader1</string>
+    <string name="settings_advanced_custom_header_1_title">CF-Access-Client-Id</string>
+    <string name="settings_advanced_custom_header_1_summary_empty">Not set (Cloudflare Zero Trust disabled)</string>
+    <string name="settings_advanced_custom_header_1_summary_set">Set (Cloudflare Zero Trust enabled)</string>
+    <string name="settings_advanced_custom_header_1_description">Enter your Cloudflare Access Client ID for Zero Trust authentication</string>
+    <string name="settings_advanced_custom_header_2_key">CustomHeader2</string>
+    <string name="settings_advanced_custom_header_2_title">CF-Access-Client-Secret</string>
+    <string name="settings_advanced_custom_header_2_summary_empty">Not set (Cloudflare Zero Trust disabled)</string>
+    <string name="settings_advanced_custom_header_2_summary_set">Set (Cloudflare Zero Trust enabled)</string>
+    <string name="settings_advanced_custom_header_2_description">Enter your Cloudflare Access Client Secret for Zero Trust authentication</string>
     <string name="settings_about_header">About</string>
     <string name="settings_about_version_title">Version</string>
     <string name="settings_about_version_format">ntfy %1$s (%2$s)</string>

--- a/app/src/main/res/xml/custom_headers_preferences.xml
+++ b/app/src/main/res/xml/custom_headers_preferences.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+    <Preference
+        app:key="add_custom_header"
+        app:title="@string/custom_headers_add_header"
+        app:summary="@string/custom_headers_add_summary" />
+</PreferenceScreen>

--- a/app/src/main/res/xml/main_preferences.xml
+++ b/app/src/main/res/xml/main_preferences.xml
@@ -98,6 +98,16 @@
                 app:key="@string/settings_advanced_clear_logs_key"
                 app:title="@string/settings_advanced_clear_logs_title"
                 app:summary="@string/settings_advanced_clear_logs_summary"/>
+        <EditTextPreference
+                app:key="@string/settings_advanced_custom_header_1_key"
+                app:title="@string/settings_advanced_custom_header_1_title"
+                app:dialogTitle="@string/settings_advanced_custom_header_1_title"
+                app:dialogMessage="@string/settings_advanced_custom_header_1_description" />
+        <EditTextPreference
+                app:key="@string/settings_advanced_custom_header_2_key"
+                app:title="@string/settings_advanced_custom_header_2_title"
+                app:dialogTitle="@string/settings_advanced_custom_header_2_title"
+                app:dialogMessage="@string/settings_advanced_custom_header_2_description" />
     </PreferenceCategory>
     <PreferenceCategory app:title="@string/settings_about_header">
         <Preference

--- a/app/src/main/res/xml/main_preferences.xml
+++ b/app/src/main/res/xml/main_preferences.xml
@@ -98,16 +98,11 @@
                 app:key="@string/settings_advanced_clear_logs_key"
                 app:title="@string/settings_advanced_clear_logs_title"
                 app:summary="@string/settings_advanced_clear_logs_summary"/>
-        <EditTextPreference
-                app:key="@string/settings_advanced_custom_header_1_key"
-                app:title="@string/settings_advanced_custom_header_1_title"
-                app:dialogTitle="@string/settings_advanced_custom_header_1_title"
-                app:dialogMessage="@string/settings_advanced_custom_header_1_description" />
-        <EditTextPreference
-                app:key="@string/settings_advanced_custom_header_2_key"
-                app:title="@string/settings_advanced_custom_header_2_title"
-                app:dialogTitle="@string/settings_advanced_custom_header_2_title"
-                app:dialogMessage="@string/settings_advanced_custom_header_2_description" />
+        <Preference
+                app:key="@string/settings_advanced_custom_headers_key"
+                app:title="@string/settings_advanced_custom_headers_title"
+                app:summary="@string/settings_advanced_custom_headers_summary"
+                app:fragment="io.heckel.ntfy.ui.CustomHeadersFragment" />
     </PreferenceCategory>
     <PreferenceCategory app:title="@string/settings_about_header">
         <Preference


### PR DESCRIPTION
Hi @binwiederhier here the PR as discussed on discord.

This PR adds the functionality to add custom Headers to all webrequest.
This gives an significant amount of flexibility while allowing a lot of customisation.

This is especially useful in situations like this:

- User want to run Cloudflare Access infront of the app.
> While this additional login will work for the webui, the app obviously wont work as it only sees that login page and no ntfy instance.
> Cloudflare allows Service token e.g. a Client-ID and Client-Secret Header to be added to bypass that loginscreen

- User runs some sort of SSO infront of ntfy
> Which again can be overcome by using custom Headers.

- User runs a custom Reverse Proxy with hardened security
> This feature allows the use to add a strong key phrase as header for more security.

Technical details:

- Custom headers are stored as JSON in SharedPreferences for scalability
- Headers are applied globally to all HTTP requests (REST API, WebSocket, polling)
- Service automatically restarts when headers are modified to ensure immediate application
- Header names are validated according to RFC 7230 standards

I implemented another sub-settingspage to make it possible to add multiple headers.

The visibility is made to hidden for all keys as a suggestion by @wunter8.

This closes: 
- #116
- https://github.com/binwiederhier/ntfy/issues/1018

And possibly related to this: https://github.com/binwiederhier/ntfy/issues/601 ?

Hopefully @cyb3rko could migrate this to the new UI too?

EDIT: Please review carefully I've not done a lot of android development lately :D