### PR TITLE
Add support for server URLs with non-standard port numbers

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/ui/DetailActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/DetailActivity.kt
@@ -97,7 +97,18 @@ class DetailActivity : AppCompatActivity(), ActionMode.Callback, NotificationFra
             return
         }
         val secure = url.getBooleanQueryParameter("secure", true)
-        val baseUrl = if (secure) "https://${url.host}" else "http://${url.host}"
+        var baseUrl = "https://${url.host}"
+        if (secure) {
+            if (url.port != 443 && url.port != -1) {
+                baseUrl = "https://${url.host}:${url.port}"
+            }
+        } else {
+            if (url.port != 80 && url.port != -1) {
+                baseUrl = "http://${url.host}:${url.port}"
+            } else {
+                baseUrl = "http://${url.host}"
+            }
+        }
         val topic = url.pathSegments.first()
         title = topicShortUrl(baseUrl, topic)
 


### PR DESCRIPTION
This change adds support for non-standard port numbers in the NTFY server host URLs, e.g. https://some.host.somewhere:8443 or http://insecure.host.somewhere:8080

With current behavior, messages received from a server hosted on non-standard ports do not recognize existing subscriptions with non-standard port numbers and create new subscriptions to either HTTPS or HTTP default ports.