### PR TITLE
Fix websocket retry loop

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/service/SubscriberService.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/SubscriberService.kt
@@ -148,7 +148,9 @@ class SubscriberService : Service() {
     override fun onDestroy() {
         Log.d(TAG, "Subscriber service has been destroyed")
         stopService()
-        sendBroadcast(Intent(this, AutoRestartReceiver::class.java)) // Restart it if necessary!
+        if (isServiceStarted) {
+            sendBroadcast(Intent(this, AutoRestartReceiver::class.java)) // Restart it if necessary!
+        }
         super.onDestroy()
     }
 
@@ -264,7 +266,7 @@ class SubscriberService : Service() {
             val connection = if (connectionId.connectionProtocol == Repository.CONNECTION_PROTOCOL_WS) {
                 val alarmManager = getSystemService(ALARM_SERVICE) as AlarmManager
                 val httpClient = HttpUtil.wsClient(this, connectionId.baseUrl)
-                WsConnection(connectionId, repository, httpClient, user, customHeaders, ::onConnectionDetailsChanged, ::onNotificationReceived, alarmManager)
+                WsConnection(connectionId, repository, httpClient, user, customHeaders, ::onConnectionDetailsChanged, ::onNotificationReceived, alarmManager, { isNetworkAvailable(this) })
             } else {
                 JsonConnection(connectionId, repository, api, user, ::onConnectionDetailsChanged, ::onNotificationReceived, serviceActive)
             }

--- a/app/src/main/java/io/heckel/ntfy/service/SubscriberService.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/SubscriberService.kt
@@ -147,10 +147,10 @@ class SubscriberService : Service() {
 
     override fun onDestroy() {
         Log.d(TAG, "Subscriber service has been destroyed")
-        stopService()
         if (isServiceStarted) {
             sendBroadcast(Intent(this, AutoRestartReceiver::class.java)) // Restart it if necessary!
         }
+        stopService()
         super.onDestroy()
     }
 

--- a/app/src/main/java/io/heckel/ntfy/service/SubscriberServiceManager.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/SubscriberServiceManager.kt
@@ -68,7 +68,12 @@ class SubscriberServiceManager(private val context: Context) {
                         notificationManager.cancel(SubscriberService.NOTIFICATION_CONNECTION_ALERT_ID)
                     }
                     Intent(context, SubscriberService::class.java).also {
-                        context.stopService(it)
+                        it.action = SubscriberService.Action.STOP.name
+                        try {
+                            ContextCompat.startForegroundService(context, it)
+                        } catch (e: Exception) {
+                            Log.w(TAG, "ServiceStartWorker: Failed to stop foreground service cleanly: ${e.message}")
+                        }
                     }
                 }
             }

--- a/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
+++ b/app/src/main/java/io/heckel/ntfy/service/WsConnection.kt
@@ -44,9 +44,9 @@ class WsConnection(
     private val customHeaders: List<CustomHeader>,
     private val connectionDetailsListener: (String, ConnectionState, Throwable?, Long) -> Unit,
     private val notificationListener: (Subscription, Notification) -> Unit,
-    private val alarmManager: AlarmManager
-) : Connection {
-    private val parser = NotificationParser()
+    private val alarmManager: AlarmManager,
+    private val networkActive: () -> Boolean
+    ) : Connection {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var errorCount = 0
     private var webSocket: WebSocket? = null
@@ -60,6 +60,7 @@ class WsConnection(
     private val topicsToSubscriptionIds = connectionId.topicsToSubscriptionIds
     private val topicsStr = topicsToSubscriptionIds.keys.joinToString(separator = ",")
     private val shortUrl = topicShortUrl(baseUrl, topicsStr)
+    private val parser = NotificationParser()
 
     init {
         Log.d(TAG, "$shortUrl (gid=$globalId): New connection with global ID $globalId")
@@ -73,6 +74,10 @@ class WsConnection(
         }
         if (webSocket != null) {
             webSocket!!.close(WS_CLOSE_NORMAL, "")
+        }
+        if (!networkActive()) {
+            Log.d(TAG, "$shortUrl (gid=$globalId): Not starting connection, because network is not active")
+            return
         }
         state = State.Connecting
         val nextListenerId = listenerId.incrementAndGet()
@@ -101,6 +106,10 @@ class WsConnection(
     fun scheduleReconnect(seconds: Int) {
         if (closed || state == State.Connecting || state == State.Connected) {
             Log.d(TAG,"$shortUrl (gid=$globalId): Not rescheduling connection, because connection is marked closed/connecting/connected")
+            return
+        }
+        if (!networkActive()) {
+            Log.d(TAG, "$shortUrl (gid=$globalId): Not rescheduling connection, because network is not active")
             return
         }
         state = State.Scheduled


### PR DESCRIPTION
Fixes [#1662](https://github.com/binwiederhier/ntfy/issues/1662)

Disclaimer: I heavily leaned on coding agents for this because I'm quite unfamiliar with both Kotlin and Android as a platform.

I observed that when Airplane mode was enabled overnight, ntfy (using WebSockets) attempted to reconnect every two minutes, resulting in significant battery drain (as reported by the Android batter stats, so to be taken with a grain of salt). This PR prevents the app from attempting to reconnect when the system reports no connectivity, a fix I have verified through emulator testing - to my best knowledge.

## Overview
This report documents two related issues that cause battery drain when network connectivity is lost (e.g., Airplane Mode):
1. **Redundant WebSocket Retries:** `WsConnection` continues to schedule `AlarmManager` wakeups and connection attempts every 120 seconds even when the OS confirms the network is unavailable.
2. **Intentional Stop Loop:** When the app intentionally stops the `SubscriberService` (due to no network), the service's `onDestroy` method triggers an auto-restart, causing a redundant start/stop cycle.

## Environment
- **Device:** in-vitro Android Emulator (API 36), in-vivo Pixel 8 Pro (GrapheneOS)
- **App Version:** `main` branch (post-ff128772)
- **Build Variant:** `fdroidDebug`
- **Configuration:** Instant delivery via WebSocket (`ws`)

## Reproduction Steps

### 1. Preparation
```bash
# Force-start the app and add a subscription via deep link
adb shell am start -a android.intent.action.VIEW -d "ntfy://ntfy.sh/myreprotopic"

# Manually set instant=1 in AppDatabase to ensure the foreground service is required
# (Column 4 is the 'instant' flag)
adb shell "run-as io.heckel.ntfy.debug sqlite3 /data/data/io.heckel.ntfy.debug/databases/AppDatabase 'UPDATE Subscription SET instant=1 WHERE topic=\"myreprotopic\";'"

# Force the connection protocol to 'ws' (WebSocket) in Shared Preferences
# This ensures we are testing the WsConnection logic specifically.
adb shell "run-as io.heckel.ntfy.debug sed -i 's|</map>|    <string name=\"ConnectionProtocol\">ws</string>\n</map>|' /data/data/io.heckel.ntfy.debug/shared_prefs/MainPreferences.xml"

# Force-stop and restart to ensure all database and preference changes are active
adb shell am force-stop io.heckel.ntfy.debug
adb shell am start -n io.heckel.ntfy.debug/io.heckel.ntfy.ui.MainActivity
```

### 2. Triggering & Observation
```bash
# Enable Airplane Mode
adb shell cmd connectivity airplane-mode enable

# Monitor logcat for the interaction between the Manager, the Service, and the Connection
adb logcat -v time | grep -E "NtfyWsConnection|NtfySubscriberService|AutoRestartReceiver"
```

## Evidence & Analysis

### Issue 1: The 120s WebSocket Retry (Dormant Battery Drain)
Even while the device was offline, the logs showed `WsConnection` scheduling retries:
```log
04-05 16:36:48.014 E/NtfyWsConnection: Connection failed: Software caused connection abort
04-05 16:36:48.014 D/NtfyWsConnection: Scheduling a restart in 5 seconds (via alarm manager)
```
**Analysis:** `WsConnection` was not checking `isNetworkAvailable()` before scheduling alarms. On a device in Airplane Mode for hours, this causes unnecessary CPU wakeups every 2 minutes.

### Issue 2: The "I died" Loop (The "Zombie Loop")
When the network is lost, the following sequence occurs:
1. `ServiceStartWorker` (invoked by WorkManager) sees no network and calls `stopService()`.
2. `SubscriberService.onDestroy()` is called.
3. **The Bug:** `onDestroy()` unconditionally sends a broadcast to `AutoRestartReceiver`.
4. `AutoRestartReceiver` enqueues a new worker, which starts and immediately stops the service again.

```log
16:36:48.022 D/NtfySubscriberService: Subscriber service has been destroyed
16:36:48.042 D/NtfySubscriberService: AutoRestartReceiver: onReceive called
16:36:48.063 D/NtfySubscriberMgr: ServiceStartWorker: Stopping service ...
```

## Applied Fixes

I tried to be as minimal as possible. However, due to my limited platform knowledge I might have misunderstood the code or missed edge cases.

1. **Network-Aware WebSocket:** Added a `networkActive` check to `WsConnection`. It now aborts connection attempts and Alarms if the OS reports the network is down.
2. **Soft Stop Mechanism:** 
    * Updated `SubscriberServiceManager` to stop the service via an `Action.STOP` intent. 
    * In the service, this action triggers a "Soft Stop" that sets `isServiceStarted = false` **before** the service shuts down.
    * `onDestroy()` now checks this sentinel. If it's still `true`, it means the OS is stopping the service unexpectedly (e.g., resource management), and the `AutoRestartReceiver` is broadcast to ensure recovery. 
    * For "Hard Kills" where `onDestroy()` is not called, the service relies on its `START_STICKY` return value for system-level reincarnation.o

I think 1. is straight forward. However, I'm not sure if the approach in 2., using a sentinel value, is the best choice and fits in with the rest of the code.

### Verification (Post-Fix)
After applying the patches, the logs show a clean shutdown with no follow-up restarts or alarms when the network is lost:
```log
11:45:36.972 D/NtfySubscriberService: onStartCommand executed with action STOP
11:45:36.972 D/NtfySubscriberService: Stopping the foreground service
11:45:36.989 D/NtfySubscriberService: Subscriber service has been destroyed
# [LOG ENDS - No AutoRestartReceiver broadcast sent because isServiceStarted was false]
```

## Test Scenarios (Post-Fix)

To ensure the fix is robust across all connectivity states, the following scenarios were verified in the emulator:

### 1. Scenario: True Offline (Airplane Mode / All Radios Disabled)
*   **Action:** `adb shell cmd connectivity airplane-mode enable` (ensuring WiFi and Data are off).
*   **Observation:** Service stops immediately. `WsConnection` logs: `Not starting/rescheduling... network not active`. 

### 2. Scenario: "Flight WiFi" (Airplane Mode + WiFi Re-enabled)
*   **Action:** Enable Airplane Mode (`cmd connectivity airplane-mode enable`), then manually re-enable WiFi (`svc wifi enable`).
*   **Observation:** The app correctly detects the active interface despite the Airplane Mode flag. Service starts and establishes a WebSocket connection.

### 3. Scenario: Spotty/Throttled Network (Interface Up, Server Unreachable)
*   **Action:** Blocked `ntfy.sh` traffic via `iptables` while keeping WiFi active.
*   **Observation:** `WsConnection` correctly detects the failure but, seeing an active interface, **schedules a retry** via `AlarmManager` with exponential backoff (5s, 10s, 30s...).

### 4. Scenario: Resource Cleanup & Recovery
*   **Action:** Re-enabled all radios and flushed all firewall blocks.
*   **Observation:** The app immediately recovered and re-established the connection: `ntfy.sh/myreprotopic (gid=2, lid=1): Opened connection`.

### 5. Scenario: Service Recovery (Manual Process Termination)
*   **Action:** While the service was active and connected, the app process was terminated manually using `adb shell kill -9`.
*   **Observation:** The system successfully restarted the service within seconds (verified via logs), confirming that the new "Soft Stop" mechanism does not interfere with legitimate crash or OS-level recovery.
