### PR TITLE
SEND_MESSAGE intent file support

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/msg/BroadcastService.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/BroadcastService.kt
@@ -2,6 +2,7 @@ package io.heckel.ntfy.msg
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import io.heckel.ntfy.R
 import io.heckel.ntfy.db.Action
 import io.heckel.ntfy.db.Notification
@@ -83,10 +84,24 @@ class BroadcastService(private val ctx: Context) {
                 else -> 0
             }
             val delay = getStringExtra(intent,"delay") ?: ""
+            val fileUriString = getStringExtra(intent, "file_uri")
+            val filenameOverride = getStringExtra(intent, "filename") ?: ""
             GlobalScope.launch(Dispatchers.IO) {
                 val repository = Repository.getInstance(ctx)
                 val user = repository.getUser(baseUrl) // May be null
                 try {
+                    val (body, filename) = if (fileUriString != null) {
+                        val uri = Uri.parse(fileUriString)
+                        if (uri.scheme != "content") {
+                            Log.w(TAG, "file_uri must use the content:// scheme, got ${uri.scheme}://. Aborting.")
+                            return@launch
+                        }
+                        val stat = fileStat(ctx, uri)
+                        val body = ContentUriRequestBody(ctx.contentResolver, uri, stat.size)
+                        Pair(body, filenameOverride.ifEmpty { stat.filename })
+                    } else {
+                        Pair(null, "") // filename ignored when no file_uri
+                    }
                     Log.d(TAG, "Publishing message $intent")
                     api.publish(
                         baseUrl = baseUrl,
@@ -96,7 +111,9 @@ class BroadcastService(private val ctx: Context) {
                         title = title,
                         priority = priority,
                         tags = splitTags(tags),
-                        delay = delay
+                        delay = delay,
+                        body = body,
+                        filename = filename,
                     )
                 } catch (e: Exception) {
                     Log.w(TAG, "Unable to publish message: ${e.message}", e)

--- a/app/src/main/java/io/heckel/ntfy/msg/BroadcastService.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/BroadcastService.kt
@@ -93,9 +93,10 @@ class BroadcastService(private val ctx: Context) {
                     val (body, filename) = if (fileUriString != null) {
                         val uri = Uri.parse(fileUriString)
                         if (uri.scheme != "content") {
-                            Log.w(TAG, "file_uri must use the content:// scheme, got ${uri.scheme}://. Aborting.")
+                            Log.w(TAG, "file_uri must use the content:// scheme, got '${uri.scheme}'. Aborting.")
                             return@launch
                         }
+                        // fileStat() throws on invalid/missing URI; caught below
                         val stat = fileStat(ctx, uri)
                         val body = ContentUriRequestBody(ctx.contentResolver, uri, stat.size)
                         Pair(body, filenameOverride.ifEmpty { stat.filename })


### PR DESCRIPTION
First off, I'm a huge fan of ntfy and it's one of my favorite self-hosted apps!

Anyways, I am building https://codeberg.org/clipshift/android which uses ntfy as the backend and on android uses the ntfy app's intents so subscriptions don't have to be configured in 2 apps. I was adding image and long-text support when I realized that the SEND_MESSAGE intent didn't support files. So with the help of my friend Claude (I'm a backend dev with very little android dev experience) I added it.

I have tested it successfully with the dedug build, though it should probably be noted in the documentation that `context.grantUriPermission("io.heckel.ntfy[.debug]", contentUriObject, Intent.FLAG_GRANT_READ_URI_PERMISSION)` must be called before the intent is broadcast. So this may not work with automation apps like Tasker unless they already do that (haven't tested that).