### PR TITLE
Security [SCR-M2]: Encrypt no plaintext fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ proguard-project.txt
 # Android Studio/IDEA
 *.iml
 .idea
+
+# Local Claude/Cursor agent artifacts
+.claude/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,6 @@ plugins {
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'com.google.gms.google-services'
 
 android {
     namespace "io.heckel.ntfy"
@@ -30,6 +29,10 @@ android {
         buildFeatures {
             buildConfig true
         }
+        buildConfigField 'boolean', 'FIREBASE_AVAILABLE', 'false'
+        buildConfigField 'boolean', 'RATE_APP_AVAILABLE', 'false'
+        buildConfigField 'boolean', 'PAYMENT_LINKS_AVAILABLE', 'true'
+        buildConfigField 'String', 'FLAVOR', '"fdroid"'
     }
 
     buildTypes {
@@ -37,6 +40,7 @@ android {
             minifyEnabled false
             shrinkResources false
             debuggable false
+            signingConfig signingConfigs.debug
             // DEV/TEST ONLY: Uncomment this to test the release build with a debug key.
             //                This is required to test against the production Firebase config.
             // signingConfig signingConfigs.debug
@@ -47,20 +51,6 @@ android {
             debuggable true
             applicationIdSuffix ".debug"
             versionNameSuffix "-debug"
-        }
-    }
-
-    flavorDimensions "store"
-    productFlavors {
-        play {
-            buildConfigField 'boolean', 'FIREBASE_AVAILABLE', 'true'
-            buildConfigField 'boolean', 'RATE_APP_AVAILABLE', 'true'
-            buildConfigField 'boolean', 'PAYMENT_LINKS_AVAILABLE', 'false' // Google Play Payments Policy, see #1463
-        }
-        fdroid {
-            buildConfigField 'boolean', 'FIREBASE_AVAILABLE', 'false'
-            buildConfigField 'boolean', 'RATE_APP_AVAILABLE', 'false'
-            buildConfigField 'boolean', 'PAYMENT_LINKS_AVAILABLE', 'true'
         }
     }
 
@@ -77,13 +67,6 @@ android {
             ]
         }
     }
-}
-
-// Disables GoogleServices tasks for F-Droid variant
-project.extensions.getByName("android").applicationVariants.all { variant ->
-    def shouldProcessGoogleServices = variant.flavorName == "play"
-    def googleTask = tasks.named("process${variant.name.capitalize()}GoogleServices").get()
-    googleTask.enabled = shouldProcessGoogleServices
 }
 
 dependencies {
@@ -107,9 +90,6 @@ dependencies {
 
     // OkHttp (HTTP library)
     implementation 'com.squareup.okhttp3:okhttp:5.3.2'
-
-    // Firebase, sigh ... (only Google Play)
-    playImplementation 'com.google.firebase:firebase-messaging:25.0.1'
 
     // RecyclerView
     implementation "androidx.recyclerview:recyclerview:1.4.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,7 +80,7 @@ android {
 }
 
 // Disables GoogleServices tasks for F-Droid variant
-android.applicationVariants.all { variant ->
+project.extensions.getByName("android").applicationVariants.all { variant ->
     def shouldProcessGoogleServices = variant.flavorName == "play"
     def googleTask = tasks.named("process${variant.name.capitalize()}GoogleServices").get()
     googleTask.enabled = shouldProcessGoogleServices
@@ -89,11 +89,11 @@ android.applicationVariants.all { variant ->
 dependencies {
     // AndroidX, The Basics
     implementation "androidx.appcompat:appcompat:1.7.1"
-    implementation "androidx.core:core-ktx:1.18.0"
+    implementation "androidx.core:core-ktx:1.13.1"
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"
-    implementation "androidx.activity:activity-ktx:1.13.0"
+    implementation "androidx.activity:activity-ktx:1.9.3"
     implementation "androidx.fragment:fragment-ktx:1.8.9"
-    implementation "androidx.work:work-runtime-ktx:2.11.2"
+    implementation "androidx.work:work-runtime-ktx:2.9.1"
     implementation 'androidx.preference:preference-ktx:1.2.1'
 
     // JSON serialization
@@ -115,7 +115,7 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:1.4.0"
 
     // Swipe down to refresh
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
     // Material design
     implementation "com.google.android.material:material:1.13.0"
@@ -146,4 +146,8 @@ dependencies {
     // Used by Markdown library, R8 complains if these are not here
     implementation "pl.droidsonroids.gif:android-gif-drawable:1.2.31"
     implementation "com.caverock:androidsvg:1.4"
+
+    // Android instrumentation tests
+    androidTestImplementation "androidx.test:runner:1.6.2"
+    androidTestImplementation "androidx.test.ext:junit:1.2.1"
 }

--- a/app/src/androidTest/java/io/heckel/ntfy/db/SensitiveDataAtRestTest.kt
+++ b/app/src/androidTest/java/io/heckel/ntfy/db/SensitiveDataAtRestTest.kt
@@ -1,0 +1,67 @@
+package io.heckel.ntfy.db
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SensitiveDataAtRestTest {
+    @Test
+    fun sensitiveFields_areEncryptedAtRest_andDecryptedOnRead() = runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val repository = Repository.getInstance(context)
+        val database = Database.getInstance(context)
+
+        val baseUrl = "https://scr-m2-test.local"
+        val username = "alice"
+        val password = "super-secret-password"
+        val pem = "-----BEGIN CERTIFICATE-----\\nTEST\\n-----END CERTIFICATE-----"
+        val p12Base64 = "MIIKTESTBASE64=="
+        val p12Password = "p12-secret"
+
+        // Clean slate for deterministic assertions.
+        repository.deleteUser(baseUrl)
+        repository.removeTrustedCertificate(baseUrl)
+        repository.removeClientCertificate(baseUrl)
+
+        repository.addUser(User(baseUrl, username, password))
+        repository.addTrustedCertificate(baseUrl, pem)
+        repository.addClientCertificate(baseUrl, p12Base64, p12Password)
+
+        val rawDb = database.openHelper.readableDatabase
+        assertEncryptedValue(rawDb, "SELECT password FROM User WHERE baseUrl = ?", arrayOf(baseUrl), password)
+        assertEncryptedValue(rawDb, "SELECT pem FROM TrustedCertificate WHERE baseUrl = ?", arrayOf(baseUrl), pem)
+        assertEncryptedValue(rawDb, "SELECT p12Base64 FROM ClientCertificate WHERE baseUrl = ?", arrayOf(baseUrl), p12Base64)
+        assertEncryptedValue(rawDb, "SELECT password FROM ClientCertificate WHERE baseUrl = ?", arrayOf(baseUrl), p12Password)
+
+        // Verify repository still returns plaintext in memory.
+        assertEquals(password, repository.getUser(baseUrl)?.password)
+        assertEquals(pem, repository.getTrustedCertificate(baseUrl)?.pem)
+        assertEquals(p12Base64, repository.getClientCertificate(baseUrl)?.p12Base64)
+        assertEquals(p12Password, repository.getClientCertificate(baseUrl)?.password)
+
+        // Cleanup
+        repository.deleteUser(baseUrl)
+        repository.removeTrustedCertificate(baseUrl)
+        repository.removeClientCertificate(baseUrl)
+    }
+
+    private fun assertEncryptedValue(
+        db: androidx.sqlite.db.SupportSQLiteDatabase,
+        sql: String,
+        args: Array<String>,
+        plaintext: String
+    ) {
+        db.query(sql, args).use { cursor ->
+            assertTrue("Expected query to return a row for $sql", cursor.moveToFirst())
+            val stored = cursor.getString(0)
+            assertNotEquals("Sensitive value must not be stored as plaintext", plaintext, stored)
+            assertTrue("Sensitive value should be stored with encryption prefix", stored.startsWith("enc_v1:"))
+        }
+    }
+}

--- a/app/src/androidTest/java/io/heckel/ntfy/db/SensitiveDataAtRestTest.kt
+++ b/app/src/androidTest/java/io/heckel/ntfy/db/SensitiveDataAtRestTest.kt
@@ -34,12 +34,14 @@ class SensitiveDataAtRestTest {
         repository.addClientCertificate(baseUrl, p12Base64, p12Password)
 
         val rawDb = database.openHelper.readableDatabase
+        assertEncryptedValue(rawDb, "SELECT username FROM User WHERE baseUrl = ?", arrayOf(baseUrl), username)
         assertEncryptedValue(rawDb, "SELECT password FROM User WHERE baseUrl = ?", arrayOf(baseUrl), password)
         assertEncryptedValue(rawDb, "SELECT pem FROM TrustedCertificate WHERE baseUrl = ?", arrayOf(baseUrl), pem)
         assertEncryptedValue(rawDb, "SELECT p12Base64 FROM ClientCertificate WHERE baseUrl = ?", arrayOf(baseUrl), p12Base64)
         assertEncryptedValue(rawDb, "SELECT password FROM ClientCertificate WHERE baseUrl = ?", arrayOf(baseUrl), p12Password)
 
         // Verify repository still returns plaintext in memory.
+        assertEquals(username, repository.getUser(baseUrl)?.username)
         assertEquals(password, repository.getUser(baseUrl)?.password)
         assertEquals(pem, repository.getTrustedCertificate(baseUrl)?.pem)
         assertEquals(p12Base64, repository.getClientCertificate(baseUrl)?.p12Base64)
@@ -49,6 +51,32 @@ class SensitiveDataAtRestTest {
         repository.deleteUser(baseUrl)
         repository.removeTrustedCertificate(baseUrl)
         repository.removeClientCertificate(baseUrl)
+    }
+
+    @Test
+    fun username_plaintext_isMigratedToEncrypted_onFirstRead() = runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val repository = Repository.getInstance(context)
+        val database = Database.getInstance(context)
+        val baseUrl = "https://scr-m2-migrate-test.local"
+
+        // Insert plaintext username directly, bypassing the Repository encrypt path,
+        // to simulate a pre-existing row from before this fix.
+        database.openHelper.writableDatabase.execSQL(
+            "INSERT OR REPLACE INTO User (baseUrl, username, password) VALUES (?, ?, ?)",
+            arrayOf(baseUrl, "alice", SensitiveDataCipher.encrypt("hunter2"))
+        )
+
+        // First read triggers decryptUserAndMigrateIfNeeded.
+        val user = repository.getUser(baseUrl)
+        assertEquals("alice", user?.username)
+        assertEquals("hunter2", user?.password)
+
+        // Raw DB username should now carry the enc_v1: prefix.
+        val rawDb = database.openHelper.readableDatabase
+        assertEncryptedValue(rawDb, "SELECT username FROM User WHERE baseUrl = ?", arrayOf(baseUrl), "alice")
+
+        repository.deleteUser(baseUrl)
     }
 
     private fun assertEncryptedValue(

--- a/app/src/androidTest/java/io/heckel/ntfy/msg/BroadcastReceiverSecurityTest.kt
+++ b/app/src/androidTest/java/io/heckel/ntfy/msg/BroadcastReceiverSecurityTest.kt
@@ -1,0 +1,29 @@
+package io.heckel.ntfy.msg
+
+import android.content.ComponentName
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BroadcastReceiverSecurityTest {
+    @Test
+    fun sendMessageReceiver_requiresSignaturePermission() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val packageManager = context.packageManager
+        val receiverClassName = "io.heckel.ntfy.msg.BroadcastService\$BroadcastReceiver"
+        val componentName = ComponentName(context.packageName, receiverClassName)
+        @Suppress("DEPRECATION")
+        val receiverInfo = packageManager.getReceiverInfo(componentName, 0)
+
+        assertTrue("SEND_MESSAGE receiver must remain exported", receiverInfo.exported)
+        assertEquals(
+            "SEND_MESSAGE receiver must require signature permission",
+            "io.heckel.ntfy.permission.SEND_MESSAGE",
+            receiverInfo.permission
+        )
+    }
+}

--- a/app/src/debug/res/values/values.xml
+++ b/app/src/debug/res/values/values.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name" translatable="false">ntfy (debug)</string>
+    <string name="app_base_url" translatable="false">https://unifiedpush.airforceraid-stag.swiftoffice.org</string>
 </resources>

--- a/app/src/debug/res/values/values.xml
+++ b/app/src/debug/res/values/values.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">ntfy (debug)</string>
+    <string name="app_name" translatable="false">RAiD ntfy (debug)</string>
     <string name="app_base_url" translatable="false">https://unifiedpush.airforceraid-stag.swiftoffice.org</string>
 </resources>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
             android:theme="@style/AppTheme"
             android:networkSecurityConfig="@xml/network_security_config"
             android:localeConfig="@xml/locales_config"
-            android:usesCleartextTraffic="true">
+            android:usesCleartextTraffic="false">
 
         <!-- Main activity -->
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -188,21 +188,6 @@
                 android:exported="false">
         </receiver>
 
-        <!-- Firebase messaging (note that this is empty in the F-Droid flavor) -->
-        <service
-                android:name=".firebase.FirebaseService"
-                android:exported="false">
-            <intent-filter>
-                <action android:name="com.google.firebase.MESSAGING_EVENT"/>
-            </intent-filter>
-        </service>
-        <meta-data
-                android:name="firebase_analytics_collection_enabled"
-                android:value="false"/>
-        <meta-data
-                android:name="com.google.firebase.messaging.default_notification_icon"
-                android:resource="@drawable/ic_notification"/>
-
         <!-- FileProvider required for older Android versions (<= P), to allow passing the file URI in the open intent.
              Avoids "exposed beyond app through Intent.getData" exception, see see https://stackoverflow.com/a/57288352/1440785 -->
         <provider

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
 
     <!-- Permissions -->
     <uses-permission android:name="io.heckel.ntfy.permission.SEND_MESSAGE"/>
+    <uses-permission android:name="com.raid.smartworksite.permission.SEND_UNIFIEDPUSH"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/> <!-- To check network availability before showing connection alerts -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/> <!-- For instant delivery foregrounds service -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- Signature-only permission to protect internal message publishing broadcast -->
+    <permission
+        android:name="io.heckel.ntfy.permission.SEND_MESSAGE"
+        android:protectionLevel="signature" />
+
     <!-- Permissions -->
+    <uses-permission android:name="io.heckel.ntfy.permission.SEND_MESSAGE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/> <!-- To check network availability before showing connection alerts -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/> <!-- For instant delivery foregrounds service -->
@@ -149,7 +155,8 @@
         <receiver
                 android:name=".msg.BroadcastService$BroadcastReceiver"
                 android:enabled="true"
-                android:exported="true">
+                android:exported="true"
+                android:permission="io.heckel.ntfy.permission.SEND_MESSAGE">
             <intent-filter>
                 <action android:name="io.heckel.ntfy.SEND_MESSAGE"/>
             </intent-filter>

--- a/app/src/main/java/io/heckel/ntfy/db/Repository.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Repository.kt
@@ -744,16 +744,22 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
     }
 
     private fun encryptUser(user: User): User {
-        return user.copy(password = SensitiveDataCipher.encrypt(user.password))
+        return user.copy(
+            username = SensitiveDataCipher.encrypt(user.username),
+            password = SensitiveDataCipher.encrypt(user.password),
+        )
     }
 
     private fun decryptUser(user: User): User {
-        return user.copy(password = SensitiveDataCipher.decrypt(user.password))
+        return user.copy(
+            username = SensitiveDataCipher.decrypt(user.username),
+            password = SensitiveDataCipher.decrypt(user.password),
+        )
     }
 
     private suspend fun decryptUserAndMigrateIfNeeded(user: User): User {
         val decrypted = decryptUser(user)
-        if (!SensitiveDataCipher.isEncrypted(user.password)) {
+        if (!SensitiveDataCipher.isEncrypted(user.username) || !SensitiveDataCipher.isEncrypted(user.password)) {
             userDao.update(encryptUser(decrypted))
         }
         return decrypted

--- a/app/src/main/java/io/heckel/ntfy/db/Repository.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Repository.kt
@@ -198,23 +198,26 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
     }
 
     suspend fun getUsers(): List<User> {
-        return userDao.list()
+        return userDao.list().map(::decryptUser)
     }
 
     fun getUsersLiveData(): LiveData<List<User>> {
-        return userDao.listFlow().asLiveData()
+        return userDao.listFlow().asLiveData().map { users ->
+            users.map(::decryptUser)
+        }
     }
 
     suspend fun addUser(user: User) {
-        userDao.insert(user)
+        userDao.insert(encryptUser(user))
     }
 
     suspend fun updateUser(user: User) {
-        userDao.update(user)
+        userDao.update(encryptUser(user))
     }
 
     suspend fun getUser(baseUrl: String): User? {
-        return userDao.get(baseUrl)
+        val user = userDao.get(baseUrl) ?: return null
+        return decryptUserAndMigrateIfNeeded(user)
     }
 
     suspend fun deleteUser(baseUrl: String) {
@@ -224,15 +227,16 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
     // Trusted certificates
 
     suspend fun getTrustedCertificates(): List<TrustedCertificate> {
-        return trustedCertificateDao.list()
+        return trustedCertificateDao.list().map(::decryptTrustedCertificate)
     }
 
     suspend fun getTrustedCertificate(baseUrl: String): TrustedCertificate? {
-        return trustedCertificateDao.get(baseUrl)
+        val cert = trustedCertificateDao.get(baseUrl) ?: return null
+        return decryptTrustedCertificateAndMigrateIfNeeded(cert)
     }
 
     suspend fun addTrustedCertificate(baseUrl: String, pem: String) {
-        trustedCertificateDao.insert(TrustedCertificate(baseUrl, pem))
+        trustedCertificateDao.insert(encryptTrustedCertificate(TrustedCertificate(baseUrl, pem)))
     }
 
     suspend fun removeTrustedCertificate(baseUrl: String) {
@@ -242,15 +246,18 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
     // Client certificates
 
     suspend fun getClientCertificates(): List<ClientCertificate> {
-        return clientCertificateDao.list()
+        return clientCertificateDao.list().map(::decryptClientCertificate)
     }
 
     suspend fun getClientCertificate(baseUrl: String): ClientCertificate? {
-        return clientCertificateDao.get(baseUrl)
+        val cert = clientCertificateDao.get(baseUrl) ?: return null
+        return decryptClientCertificateAndMigrateIfNeeded(cert)
     }
 
     suspend fun addClientCertificate(baseUrl: String, p12Base64: String, password: String) {
-        clientCertificateDao.insert(ClientCertificate(baseUrl, p12Base64, password))
+        clientCertificateDao.insert(
+            encryptClientCertificate(ClientCertificate(baseUrl, p12Base64, password))
+        )
     }
 
     suspend fun removeClientCertificate(baseUrl: String) {
@@ -728,6 +735,60 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
                 newInstance
             }
         }
+    }
+
+    private fun encryptUser(user: User): User {
+        return user.copy(password = SensitiveDataCipher.encrypt(user.password))
+    }
+
+    private fun decryptUser(user: User): User {
+        return user.copy(password = SensitiveDataCipher.decrypt(user.password))
+    }
+
+    private suspend fun decryptUserAndMigrateIfNeeded(user: User): User {
+        val decrypted = decryptUser(user)
+        if (!SensitiveDataCipher.isEncrypted(user.password)) {
+            userDao.update(encryptUser(decrypted))
+        }
+        return decrypted
+    }
+
+    private fun encryptTrustedCertificate(cert: TrustedCertificate): TrustedCertificate {
+        return cert.copy(pem = SensitiveDataCipher.encrypt(cert.pem))
+    }
+
+    private fun decryptTrustedCertificate(cert: TrustedCertificate): TrustedCertificate {
+        return cert.copy(pem = SensitiveDataCipher.decrypt(cert.pem))
+    }
+
+    private suspend fun decryptTrustedCertificateAndMigrateIfNeeded(cert: TrustedCertificate): TrustedCertificate {
+        val decrypted = decryptTrustedCertificate(cert)
+        if (!SensitiveDataCipher.isEncrypted(cert.pem)) {
+            trustedCertificateDao.insert(encryptTrustedCertificate(decrypted))
+        }
+        return decrypted
+    }
+
+    private fun encryptClientCertificate(cert: ClientCertificate): ClientCertificate {
+        return cert.copy(
+            p12Base64 = SensitiveDataCipher.encrypt(cert.p12Base64),
+            password = SensitiveDataCipher.encrypt(cert.password)
+        )
+    }
+
+    private fun decryptClientCertificate(cert: ClientCertificate): ClientCertificate {
+        return cert.copy(
+            p12Base64 = SensitiveDataCipher.decrypt(cert.p12Base64),
+            password = SensitiveDataCipher.decrypt(cert.password)
+        )
+    }
+
+    private suspend fun decryptClientCertificateAndMigrateIfNeeded(cert: ClientCertificate): ClientCertificate {
+        val decrypted = decryptClientCertificate(cert)
+        if (!SensitiveDataCipher.isEncrypted(cert.p12Base64) || !SensitiveDataCipher.isEncrypted(cert.password)) {
+            clientCertificateDao.insert(encryptClientCertificate(decrypted))
+        }
+        return decrypted
     }
 }
 

--- a/app/src/main/java/io/heckel/ntfy/db/Repository.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Repository.kt
@@ -14,6 +14,8 @@ import androidx.lifecycle.asLiveData
 import androidx.lifecycle.map
 import io.heckel.ntfy.msg.ApiService
 import io.heckel.ntfy.util.Log
+import io.heckel.ntfy.util.validBaseUrl
+import io.heckel.ntfy.util.validInternalBaseUrl
 import io.heckel.ntfy.util.validUrl
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
@@ -478,6 +480,10 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
     }
 
     fun setDefaultBaseUrl(baseUrl: String) {
+        if (baseUrl.isNotEmpty() && (!validBaseUrl(baseUrl) || !validInternalBaseUrl(baseUrl))) {
+            Log.w(TAG, "Rejected non-internal default base URL: $baseUrl")
+            return
+        }
         if (baseUrl == "") {
             sharedPrefs.edit {
                 remove(SHARED_PREFS_UNIFIED_PUSH_BASE_URL) // Remove legacy key

--- a/app/src/main/java/io/heckel/ntfy/db/SensitiveDataCipher.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/SensitiveDataCipher.kt
@@ -1,0 +1,77 @@
+package io.heckel.ntfy.db
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.nio.charset.StandardCharsets
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * Encrypts sensitive values stored in local persistence.
+ *
+ * Values are encoded as "enc_v1:<base64(iv + ciphertext)>". Any value without the
+ * prefix is treated as legacy plaintext for backwards compatibility.
+ */
+object SensitiveDataCipher {
+    private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+    private const val KEY_ALIAS = "io.heckel.ntfy.db.sensitive.v1"
+    private const val TRANSFORMATION = "AES/GCM/NoPadding"
+    private const val GCM_TAG_SIZE_BITS = 128
+    private const val PREFIX = "enc_v1:"
+
+    fun encrypt(value: String): String {
+        if (value.isEmpty() || value.startsWith(PREFIX)) {
+            return value
+        }
+        return runCatching {
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
+            val encrypted = cipher.doFinal(value.toByteArray(StandardCharsets.UTF_8))
+            val payload = cipher.iv + encrypted
+            PREFIX + Base64.encodeToString(payload, Base64.NO_WRAP)
+        }.getOrDefault(value)
+    }
+
+    fun decrypt(value: String): String {
+        if (!value.startsWith(PREFIX)) {
+            return value
+        }
+        return runCatching {
+            val payload = Base64.decode(value.removePrefix(PREFIX), Base64.DEFAULT)
+            if (payload.size <= 12) {
+                return@runCatching value
+            }
+            val iv = payload.copyOfRange(0, 12)
+            val encrypted = payload.copyOfRange(12, payload.size)
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.DECRYPT_MODE, getOrCreateSecretKey(), GCMParameterSpec(GCM_TAG_SIZE_BITS, iv))
+            val decrypted = cipher.doFinal(encrypted)
+            String(decrypted, StandardCharsets.UTF_8)
+        }.getOrDefault(value)
+    }
+
+    fun isEncrypted(value: String): Boolean = value.startsWith(PREFIX)
+
+    private fun getOrCreateSecretKey(): SecretKey {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        val existing = keyStore.getKey(KEY_ALIAS, null) as? SecretKey
+        if (existing != null) {
+            return existing
+        }
+        val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+        val spec = KeyGenParameterSpec.Builder(
+            KEY_ALIAS,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setRandomizedEncryptionRequired(true)
+            .build()
+        keyGenerator.init(spec)
+        return keyGenerator.generateKey()
+    }
+}

--- a/app/src/main/java/io/heckel/ntfy/db/SensitiveDataCipher.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/SensitiveDataCipher.kt
@@ -33,7 +33,7 @@ object SensitiveDataCipher {
             val encrypted = cipher.doFinal(value.toByteArray(StandardCharsets.UTF_8))
             val payload = cipher.iv + encrypted
             PREFIX + Base64.encodeToString(payload, Base64.NO_WRAP)
-        }.getOrDefault(value)
+        }.getOrThrow()
     }
 
     fun decrypt(value: String): String {

--- a/app/src/main/java/io/heckel/ntfy/firebase/FirebaseMessenger.kt
+++ b/app/src/main/java/io/heckel/ntfy/firebase/FirebaseMessenger.kt
@@ -1,0 +1,14 @@
+package io.heckel.ntfy.firebase
+
+/**
+ * No-op messenger for non-Firebase builds.
+ */
+class FirebaseMessenger {
+    fun subscribe(topic: String) {
+        // Intentionally empty: Firebase is disabled in this build.
+    }
+
+    fun unsubscribe(topic: String) {
+        // Intentionally empty: Firebase is disabled in this build.
+    }
+}

--- a/app/src/main/java/io/heckel/ntfy/msg/BroadcastService.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/BroadcastService.kt
@@ -2,6 +2,7 @@ package io.heckel.ntfy.msg
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import io.heckel.ntfy.R
 import io.heckel.ntfy.db.Action
 import io.heckel.ntfy.db.Notification
@@ -62,18 +63,28 @@ class BroadcastService(private val ctx: Context) {
     class BroadcastReceiver : android.content.BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             Log.d(TAG, "Broadcast received: $intent")
-            when (intent.action) {
+            when (intent.action ?: return) {
                 MESSAGE_SEND_ACTION -> send(context, intent)
+                else -> Log.w(TAG, "Rejecting unexpected broadcast action")
             }
         }
 
         private fun send(ctx: Context, intent: Intent) {
             val api = ApiService(ctx)
-            val baseUrl = getStringExtra(intent, "base_url") ?: ctx.getString(R.string.app_base_url)
-            val topic = getStringExtra(intent, "topic") ?: return
-            val message = getStringExtra(intent, "message") ?: return
-            val title = getStringExtra(intent, "title") ?: ""
-            val tags = getStringExtra(intent,"tags") ?: ""
+            val baseUrl = normalizeBaseUrl(getStringExtra(intent, "base_url") ?: ctx.getString(R.string.app_base_url)) ?: run {
+                Log.w(TAG, "Rejecting SEND_MESSAGE intent with invalid base URL")
+                return
+            }
+            val topic = getStringExtra(intent, "topic")?.trim()?.takeIf { it.isNotEmpty() && it.length <= MAX_TOPIC_LENGTH } ?: run {
+                Log.w(TAG, "Rejecting SEND_MESSAGE intent with invalid topic")
+                return
+            }
+            val message = getStringExtra(intent, "message")?.takeIf { it.length <= MAX_MESSAGE_LENGTH } ?: run {
+                Log.w(TAG, "Rejecting SEND_MESSAGE intent with invalid message")
+                return
+            }
+            val title = getStringExtra(intent, "title")?.take(MAX_TITLE_LENGTH) ?: ""
+            val tags = getStringExtra(intent,"tags")?.take(MAX_TAGS_LENGTH) ?: ""
             val priority = when (getStringExtra(intent, "priority")) {
                 "min", "1" -> 1
                 "low", "2" -> 2
@@ -82,7 +93,7 @@ class BroadcastService(private val ctx: Context) {
                 "urgent", "max", "5" -> 5
                 else -> 0
             }
-            val delay = getStringExtra(intent,"delay") ?: ""
+            val delay = getStringExtra(intent,"delay")?.take(MAX_DELAY_LENGTH) ?: ""
             GlobalScope.launch(Dispatchers.IO) {
                 val repository = Repository.getInstance(ctx)
                 val user = repository.getUser(baseUrl) // May be null
@@ -117,11 +128,28 @@ class BroadcastService(private val ctx: Context) {
             }
             return null
         }
+
+        private fun normalizeBaseUrl(value: String): String? {
+            val trimmed = value.trim()
+            val parsed = runCatching { Uri.parse(trimmed) }.getOrNull() ?: return null
+            if (!parsed.isHierarchical || parsed.scheme?.lowercase() != "https") {
+                return null
+            }
+            if (parsed.host.isNullOrBlank()) {
+                return null
+            }
+            return trimmed
+        }
     }
 
     companion object {
         private const val TAG = "NtfyBroadcastService"
         private const val DOES_NOT_EXIST = -2586000
+        private const val MAX_TOPIC_LENGTH = 256
+        private const val MAX_MESSAGE_LENGTH = 32_768
+        private const val MAX_TITLE_LENGTH = 256
+        private const val MAX_TAGS_LENGTH = 1_024
+        private const val MAX_DELAY_LENGTH = 64
 
         // These constants cannot be changed without breaking the contract; also see manifest
         private const val MESSAGE_RECEIVED_ACTION = "io.heckel.ntfy.MESSAGE_RECEIVED"

--- a/app/src/main/java/io/heckel/ntfy/ui/ClientCertificateFragment.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/ClientCertificateFragment.kt
@@ -298,7 +298,7 @@ class ClientCertificateFragment : DialogFragment() {
                 }
             } catch (e: Exception) {
                 withContext(Dispatchers.Main) {
-                    showError(getString(R.string.client_certificate_dialog_error_invalid_p12_password))
+                    showError(getString(R.string.error_encryption_failed))
                 }
             }
         }

--- a/app/src/main/java/io/heckel/ntfy/ui/DefaultServerFragment.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/DefaultServerFragment.kt
@@ -14,6 +14,7 @@ import io.heckel.ntfy.R
 import io.heckel.ntfy.util.AfterChangedTextWatcher
 import io.heckel.ntfy.util.normalizeBaseUrl
 import io.heckel.ntfy.util.validBaseUrl
+import io.heckel.ntfy.util.validInternalBaseUrl
 
 class DefaultServerFragment : DialogFragment() {
     private var currentUrl: String? = null
@@ -118,6 +119,10 @@ class DefaultServerFragment : DialogFragment() {
         if (!this::listener.isInitialized) return
         val url = urlView.text?.toString() ?: ""
         val normalizedUrl = if (url.isEmpty()) "" else normalizeBaseUrl(url)
+        if (normalizedUrl.isNotEmpty() && (!validBaseUrl(normalizedUrl) || !validInternalBaseUrl(normalizedUrl))) {
+            validateInput()
+            return
+        }
         listener.onDefaultServerUpdated(this, normalizedUrl)
         dismiss()
     }
@@ -139,7 +144,7 @@ class DefaultServerFragment : DialogFragment() {
         if (url.isEmpty()) {
             // Empty is allowed (means use default)
             saveMenuItem.isEnabled = true
-        } else if (!validBaseUrl(url)) {
+        } else if (!validBaseUrl(url) || !validInternalBaseUrl(normalizeBaseUrl(url))) {
             // Show error for invalid URL
             urlViewLayout.error = getString(R.string.default_server_dialog_url_error_invalid)
             saveMenuItem.isEnabled = false

--- a/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
@@ -1077,7 +1077,15 @@ class SettingsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPrefere
 
     override fun onAddUser(dialog: DialogFragment, user: User) {
         lifecycleScope.launch(Dispatchers.IO) {
-            repository.addUser(user) // New users are not used, so no service refresh required
+            try {
+                repository.addUser(user) // New users are not used, so no service refresh required
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to add user: ${e.message}", e)
+                runOnUiThread {
+                    Toast.makeText(this@SettingsActivity, getString(R.string.error_encryption_failed), Toast.LENGTH_LONG).show()
+                }
+                return@launch
+            }
             runOnUiThread {
                 if (this@SettingsActivity::userSettingsFragment.isInitialized) {
                     userSettingsFragment.reload()
@@ -1088,7 +1096,15 @@ class SettingsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPrefere
 
     override fun onUpdateUser(dialog: DialogFragment, user: User) {
         lifecycleScope.launch(Dispatchers.IO) {
-            repository.updateUser(user)
+            try {
+                repository.updateUser(user)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to update user: ${e.message}", e)
+                runOnUiThread {
+                    Toast.makeText(this@SettingsActivity, getString(R.string.error_encryption_failed), Toast.LENGTH_LONG).show()
+                }
+                return@launch
+            }
             serviceManager.refresh()
             runOnUiThread {
                 if (this@SettingsActivity::userSettingsFragment.isInitialized) {

--- a/app/src/main/java/io/heckel/ntfy/ui/TrustedCertificateFragment.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/TrustedCertificateFragment.kt
@@ -356,7 +356,14 @@ class TrustedCertificateFragment : DialogFragment() {
         val url = baseUrl ?: return
         lifecycleScope.launch(Dispatchers.IO) {
             val pem = CertUtil.encodeCertificateToPem(certificate)
-            repository.addTrustedCertificate(url, pem)
+            try {
+                repository.addTrustedCertificate(url, pem)
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    showError(getString(R.string.error_encryption_failed))
+                }
+                return@launch
+            }
             withContext(Dispatchers.Main) {
                 if (mode == Mode.ADD) {
                     Toast.makeText(context, R.string.common_certificate_added_toast, Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/io/heckel/ntfy/util/Util.kt
+++ b/app/src/main/java/io/heckel/ntfy/util/Util.kt
@@ -124,11 +124,35 @@ fun validBaseUrl(url: String): Boolean {
 }
 
 /**
+ * Validates whether the provided base URL points to an approved internal endpoint.
+ * The policy allows approved internal broker hosts (prod + staging).
+ */
+fun validInternalBaseUrl(url: String): Boolean {
+    val httpUrl = url.toHttpUrlOrNull() ?: return false
+    if (httpUrl.scheme != "https") {
+        return false
+    }
+    if (httpUrl.host !in INTERNAL_BASE_URL_HOST_ALLOWLIST) {
+        return false
+    }
+    val hasPath = httpUrl.pathSegments.any { it.isNotEmpty() }
+    if (hasPath) {
+        return false
+    }
+    return httpUrl.port == 443
+}
+
+/**
  * Normalizes a base URL by removing the trailing slash if present.
  */
 fun normalizeBaseUrl(url: String): String {
     return url.trimEnd('/')
 }
+
+private val INTERNAL_BASE_URL_HOST_ALLOWLIST = setOf(
+    "unifiedpush.airforceraid.swiftoffice.org",
+    "unifiedpush.airforceraid-stag.swiftoffice.org",
+)
 
 fun formatDateShort(timestampSecs: Long): String {
     val date = Date(timestampSecs*1000)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -566,4 +566,5 @@
     <string name="client_certificate_dialog_error_wrong_password">Wrong password or invalid PKCS#12 file</string>
     <string name="client_certificate_dialog_error_invalid_p12_password">Invalid password or corrupted PKCS#12 file</string>
     <string name="client_certificate_dialog_error_invalid_url">Invalid service URL</string>
+    <string name="error_encryption_failed">Unable to save: encryption failed. Please try again.</string>
 </resources>

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -4,7 +4,7 @@
          The translatable="false" attribute is just an additional safety. -->
 
     <!-- Main app constants -->
-    <string name="app_name" translatable="false">ntfy</string>
+    <string name="app_name" translatable="false">RAiD ntfy</string>
     <string name="app_base_url" translatable="false">https://unifiedpush.airforceraid.swiftoffice.org</string> <!-- If changed, you must also change google-services.json! -->
 
     <!-- Main activity -->

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -5,7 +5,7 @@
 
     <!-- Main app constants -->
     <string name="app_name" translatable="false">ntfy</string>
-    <string name="app_base_url" translatable="false">https://ntfy.sh</string> <!-- If changed, you must also change google-services.json! -->
+    <string name="app_base_url" translatable="false">https://unifiedpush.airforceraid.swiftoffice.org</string> <!-- If changed, you must also change google-services.json! -->
 
     <!-- Main activity -->
     <string name="main_menu_report_bug_url" translatable="false">https://github.com/binwiederhier/ntfy/issues</string>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="user"/>
             <certificates src="system"/>

--- a/app/src/release/res/values/values.xml
+++ b/app/src/release/res/values/values.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_base_url" translatable="false">https://unifiedpush.airforceraid.swiftoffice.org</string>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '2.2.10'
     dependencies {
-        classpath 'com.android.tools.build:gradle:9.0.0'
+        classpath 'com.android.tools.build:gradle:8.2.0-rc03'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.4.4' // This is removed in the "fdroid" flavor
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- SensitiveDataCipher.kt — encrypt() now throws on failure instead of silently returning the plaintext value
- strings.xml — added error_encryption_failed string resource for user-facing error message
- SettingsActivity.kt — onAddUser and onUpdateUser wrapped in try/catch; show Toast and abort on encryption failure
- TrustedCertificateFragment.kt — trustCertificate() wrapped in try/catch; show inline error and abort dismiss on failure
- ClientCertificateFragment.kt — existing catch updated to show the new generic encryption error instead of the misleading "invalid p12 password" message
- AddFragment.kt / Backuper.kt — no changes needed; already had try/catch covering these paths