### PR TITLE
Respect X-Persist header to skip saving messages to local history

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Get short SHA
+        id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
       - uses: actions/setup-java@v4
         with:
           java-version: '17'
@@ -32,7 +36,7 @@ jobs:
             --out app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.apk \
             app/build/outputs/apk/fdroid/release/app-fdroid-release-unsigned.apk
           rm /tmp/ntfy-release.keystore
-          zip app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.zip \
+          zip -P ntfy app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.zip \
             app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.apk
 
       - uses: actions/upload-artifact@v4
@@ -41,18 +45,46 @@ jobs:
           path: app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.apk
           retention-days: 7
 
-      - name: Send APK via email
+      - name: Send success email
+        if: success()
+        continue-on-error: true
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 587
           username: ${{ secrets.NOTIFY_EMAIL }}
           password: ${{ secrets.GMAIL_APP_PASSWORD }}
-          subject: "ntfy Android build — ${{ github.ref_name }}@${{ github.sha && github.sha || '' }}"
+          subject: "[EugeneShtoka/ntfy-android] Build succeeded: ${{ github.ref_name }} (${{ steps.sha.outputs.short }})"
           to: ${{ secrets.NOTIFY_EMAIL }}
           from: ${{ secrets.NOTIFY_FROM }}
           body: |
-            Branch: ${{ github.ref_name }}
-            Commit: ${{ github.sha }}
-            ${{ github.event.head_commit.message }}
+            ✅ Build succeeded
+
+            Branch:  ${{ github.ref_name }}
+            Commit:  ${{ github.sha }}
+            Message: ${{ github.event.head_commit.message }}
+
+            APK is attached (zip password: ntfy).
           attachments: app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.zip
+
+      - name: Send failure email
+        if: failure()
+        continue-on-error: true
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 587
+          username: ${{ secrets.NOTIFY_EMAIL }}
+          password: ${{ secrets.GMAIL_APP_PASSWORD }}
+          subject: "[EugeneShtoka/ntfy-android] Build failed: ${{ github.ref_name }} (${{ steps.sha.outputs.short }})"
+          to: ${{ secrets.NOTIFY_EMAIL }}
+          from: ${{ secrets.NOTIFY_FROM }}
+          body: |
+            ❌ Build failed
+
+            Branch:  ${{ github.ref_name }}
+            Commit:  ${{ github.sha }}
+            Message: ${{ github.event.head_commit.message }}
+
+            Check the run for details:
+            https://github.com/EugeneShtoka/ntfy-android/actions/runs/${{ github.run_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build APK
 on:
   push:
     branches: [ "**" ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,11 +17,23 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
-      - name: Build F-Droid debug APK
-        run: ./gradlew assembleFdroidDebug
+      - name: Build F-Droid release APK (unsigned)
+        run: ./gradlew assembleFdroidRelease
+
+      - name: Sign APK
+        run: |
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > /tmp/ntfy-release.keystore
+          $ANDROID_SDK_ROOT/build-tools/$(ls $ANDROID_SDK_ROOT/build-tools | sort -V | tail -1)/apksigner sign \
+            --ks /tmp/ntfy-release.keystore \
+            --ks-key-alias "${{ secrets.KEY_ALIAS }}" \
+            --ks-pass "pass:${{ secrets.KEYSTORE_PASSWORD }}" \
+            --key-pass "pass:${{ secrets.KEY_PASSWORD }}" \
+            --out app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.apk \
+            app/build/outputs/apk/fdroid/release/app-fdroid-release.apk
+          rm /tmp/ntfy-release.keystore
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ntfy-fdroid-debug
-          path: app/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk
+          name: ntfy-fdroid-release
+          path: app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.apk
           retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,3 +37,19 @@ jobs:
           name: ntfy-fdroid-release
           path: app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.apk
           retention-days: 7
+
+      - name: Send APK via email
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 587
+          username: ${{ secrets.NOTIFY_EMAIL }}
+          password: ${{ secrets.GMAIL_APP_PASSWORD }}
+          subject: "ntfy Android build — ${{ github.ref_name }}@${{ github.sha && github.sha || '' }}"
+          to: ${{ secrets.NOTIFY_EMAIL }}
+          from: ${{ secrets.NOTIFY_FROM }}
+          body: |
+            Branch: ${{ github.ref_name }}
+            Commit: ${{ github.sha }}
+            ${{ github.event.head_commit.message }}
+          attachments: app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build APK
+
+on:
+  push:
+    branches: [ "**" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Build F-Droid debug APK
+        run: ./gradlew assembleFdroidDebug
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ntfy-fdroid-debug
+          path: app/build/outputs/apk/fdroid/debug/app-fdroid-debug.apk
+          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
             --ks-pass "pass:${{ secrets.KEYSTORE_PASSWORD }}" \
             --key-pass "pass:${{ secrets.KEY_PASSWORD }}" \
             --out app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.apk \
-            app/build/outputs/apk/fdroid/release/app-fdroid-release.apk
+            app/build/outputs/apk/fdroid/release/app-fdroid-release-unsigned.apk
           rm /tmp/ntfy-release.keystore
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,6 @@ jobs:
             --out app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.apk \
             app/build/outputs/apk/fdroid/release/app-fdroid-release-unsigned.apk
           rm /tmp/ntfy-release.keystore
-          zip -P ntfy app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.zip \
-            app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.apk
 
       - uses: actions/upload-artifact@v4
         with:
@@ -58,33 +56,9 @@ jobs:
           to: ${{ secrets.NOTIFY_EMAIL }}
           from: ${{ secrets.NOTIFY_FROM }}
           body: |
-            ✅ Build succeeded
-
             Branch:  ${{ github.ref_name }}
             Commit:  ${{ github.sha }}
             Message: ${{ github.event.head_commit.message }}
 
-            APK is attached (zip password: ntfy).
-          attachments: app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.zip
-
-      - name: Send failure email
-        if: failure()
-        continue-on-error: true
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 587
-          username: ${{ secrets.NOTIFY_EMAIL }}
-          password: ${{ secrets.GMAIL_APP_PASSWORD }}
-          subject: "[EugeneShtoka/ntfy-android] Build failed: ${{ github.ref_name }} (${{ steps.sha.outputs.short }})"
-          to: ${{ secrets.NOTIFY_EMAIL }}
-          from: ${{ secrets.NOTIFY_FROM }}
-          body: |
-            ❌ Build failed
-
-            Branch:  ${{ github.ref_name }}
-            Commit:  ${{ github.sha }}
-            Message: ${{ github.event.head_commit.message }}
-
-            Check the run for details:
+            Download APK:
             https://github.com/EugeneShtoka/ntfy-android/actions/runs/${{ github.run_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
             --out app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.apk \
             app/build/outputs/apk/fdroid/release/app-fdroid-release-unsigned.apk
           rm /tmp/ntfy-release.keystore
+          zip app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.zip \
+            app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.apk
 
       - uses: actions/upload-artifact@v4
         with:
@@ -53,4 +55,4 @@ jobs:
             Branch: ${{ github.ref_name }}
             Commit: ${{ github.sha }}
             ${{ github.event.head_commit.message }}
-          attachments: app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.apk
+          attachments: app/build/outputs/apk/fdroid/release/app-fdroid-release-signed.zip

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,44 @@
+name: Rebase on upstream main
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # daily at 6am UTC
+  workflow_dispatch:      # allow manual trigger
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: x-persist-header
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add upstream remote
+        run: git remote add upstream https://github.com/binwiederhier/ntfy-android.git
+
+      - name: Fetch upstream main
+        run: git fetch upstream main
+
+      - name: Check for new upstream commits
+        id: check
+        run: |
+          UPSTREAM=$(git rev-parse upstream/main)
+          BASE=$(git merge-base HEAD upstream/main)
+          if [ "$UPSTREAM" = "$BASE" ]; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Rebase on upstream main
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          git config user.email "action@github.com"
+          git config user.name "GitHub Actions"
+          git rebase upstream/main
+
+      - name: Push rebased branch
+        if: steps.check.outputs.changed == 'true'
+        run: git push origin x-persist-header --force

--- a/app/src/main/java/io/heckel/ntfy/db/Database.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Database.kt
@@ -161,6 +161,7 @@ data class Notification(
     @Embedded(prefix = "attachment_") val attachment: Attachment?,
     @ColumnInfo(name = "deleted") val deleted: Boolean,
     @Ignore val event: String = ApiService.EVENT_MESSAGE, // In-memory event type (message, message_delete, message_clear)
+    @Ignore val persist: Boolean = true, // If false, notification should not be saved to local history
 ) {
     constructor(
         id: String,

--- a/app/src/main/java/io/heckel/ntfy/db/Repository.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Repository.kt
@@ -139,12 +139,14 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
         if (maybeExistingNotification != null || notification.event != ApiService.EVENT_MESSAGE) {
             return false
         }
-        // Mark old notifications with the same sequence ID as deleted (this is an update to an existing sequence)
-        if (notification.sequenceId.isNotEmpty()) {
-            notificationDao.markAsDeletedBySequenceId(notification.subscriptionId, notification.sequenceId)
-        }
         subscriptionDao.updateLastNotificationId(notification.subscriptionId, notification.id)
-        notificationDao.add(notification)
+        if (notification.persist) {
+            // Mark old notifications with the same sequence ID as deleted (this is an update to an existing sequence)
+            if (notification.sequenceId.isNotEmpty()) {
+                notificationDao.markAsDeletedBySequenceId(notification.subscriptionId, notification.sequenceId)
+            }
+            notificationDao.add(notification)
+        }
         return true
     }
 

--- a/app/src/main/java/io/heckel/ntfy/msg/Message.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/Message.kt
@@ -22,6 +22,7 @@ data class Message(
     @SerializedName("content_type") val contentType: String?,
     val encoding: String?,
     val attachment: MessageAttachment?,
+    val persist: Boolean?,
 )
 
 @Keep

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
@@ -73,7 +73,8 @@ class NotificationParser {
             attachment = attachment,
             notificationId = deriveNotificationId(baseUrl, topic, sequenceId),
             deleted = false,
-            event = message.event
+            event = message.event,
+            persist = message.persist ?: true,
         )
         return NotificationWithTopic(topic, notification)
     }


### PR DESCRIPTION
## Summary

When the server sends `"persist": false` in the message payload (published with `X-Persist: no`), the Android client skips inserting the notification into the local Room database. The notification is still delivered and shown as a popup, but will not appear in the app's message history.

This is useful for ephemeral notifications (e.g. clipboard sync) that should be delivered but not accumulate in local history.

## Changes

- `Message.kt` — add `persist: Boolean?` field mapped from server JSON
- `Database.kt` — add `@Ignore val persist: Boolean = true` to `Notification` (same pattern as existing `event` field — in-memory only, not stored in DB)
- `NotificationParser.kt` — populate `persist` from `message.persist`
- `Repository.kt` — skip `notificationDao.add()` when `notification.persist == false`; still updates `lastNotificationId` and returns `true` so the notification popup is dispatched normally

## Related

Server-side support: binwiederhier/ntfy#1725