### PR TITLE
Fix scrub

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/util/Log.kt
+++ b/app/src/main/java/io/heckel/ntfy/util/Log.kt
@@ -91,13 +91,15 @@ class Log(private val logsDao: LogDao) {
             }
     }
 
-    private fun scrub(line: String?): String? {
-        var newLine = line ?: return null
+private fun scrub(line: String?): String? {
+    var newLine = line ?: return null
+    synchronized(scrubTerms) {
         scrubTerms.forEach { (scrubTerm, replaceTerm) ->
             newLine = newLine.replace(scrubTerm, replaceTerm.replaceTerm)
         }
-        return newLine
     }
+    return newLine
+}
 
     private fun formatEntries(entries: List<LogEntry>): String {
         return entries.joinToString(separator = "\n") { e ->


### PR DESCRIPTION
# Fix: `scrub`

## Explanation

The reason for this error is that the `scrub()` method is not properly synchronizing access to the shared object, which is the synchronized map. Without proper synchronization, multiple threads can access the same object simultaneously, leading to race conditions and other errors. By wrapping the no

---

## Modified Method

| Property | Value |
|---|---|
| Method | `scrub` |
| Class | `io.heckel.ntfy.util.Log` |
| File | `/mnt/c/Users/Antonow/Documents/tcc-openspec-v2/cloned_projects_sample/io.heckel.ntfy_32.apk/app/src/main/java/io/heckel/ntfy/util/Log.kt` |
| Status | `SUCCESS` |

---

## Changed File

```text
/mnt/c/Users/Antonow/Documents/tcc-openspec-v2/cloned_projects_sample/io.heckel.ntfy_32.apk/app/src/main/java/io/heckel/ntfy/util/Log.kt
```

---


## Validation Checklist

- [x] Method replaced in source file
- [x] Repository updated
- [x] Commit generated
- [ ] Manual review required
- [ ] CI validation pending

---

Repair Pipeline