### PR TITLE
Add Android live notification percentage/end handling

### DIFF
--- a/app/schemas/io.heckel.ntfy.db.Database/19.json
+++ b/app/schemas/io.heckel.ntfy.db.Database/19.json
@@ -1,0 +1,441 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 19,
+    "identityHash": "66bd8123b8636f494da9297ad4260d1d",
+    "entities": [
+      {
+        "tableName": "Subscription",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `baseUrl` TEXT NOT NULL, `topic` TEXT NOT NULL, `instant` INTEGER NOT NULL, `mutedUntil` INTEGER NOT NULL, `minPriority` INTEGER NOT NULL, `autoDelete` INTEGER NOT NULL, `insistent` INTEGER NOT NULL, `lastNotificationId` TEXT, `icon` TEXT, `upAppId` TEXT, `upConnectorToken` TEXT, `displayName` TEXT, `dedicatedChannels` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topic",
+            "columnName": "topic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instant",
+            "columnName": "instant",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutedUntil",
+            "columnName": "mutedUntil",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minPriority",
+            "columnName": "minPriority",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDelete",
+            "columnName": "autoDelete",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insistent",
+            "columnName": "insistent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastNotificationId",
+            "columnName": "lastNotificationId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "upAppId",
+            "columnName": "upAppId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "upConnectorToken",
+            "columnName": "upConnectorToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dedicatedChannels",
+            "columnName": "dedicatedChannels",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Subscription_baseUrl_topic",
+            "unique": true,
+            "columnNames": [
+              "baseUrl",
+              "topic"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_Subscription_baseUrl_topic` ON `${TABLE_NAME}` (`baseUrl`, `topic`)"
+          },
+          {
+            "name": "index_Subscription_upConnectorToken",
+            "unique": true,
+            "columnNames": [
+              "upConnectorToken"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_Subscription_upConnectorToken` ON `${TABLE_NAME}` (`upConnectorToken`)"
+          }
+        ]
+      },
+      {
+        "tableName": "Notification",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `subscriptionId` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `sequenceId` TEXT NOT NULL, `title` TEXT NOT NULL, `message` TEXT NOT NULL, `contentType` TEXT NOT NULL, `encoding` TEXT NOT NULL, `notificationId` INTEGER NOT NULL, `priority` INTEGER NOT NULL DEFAULT 3, `tags` TEXT NOT NULL, `click` TEXT NOT NULL, `actions` TEXT, `deleted` INTEGER NOT NULL, `percentage` INTEGER NOT NULL, `end` INTEGER NOT NULL, `icon_url` TEXT, `icon_contentUri` TEXT, `attachment_name` TEXT, `attachment_type` TEXT, `attachment_size` INTEGER, `attachment_expires` INTEGER, `attachment_url` TEXT, `attachment_contentUri` TEXT, `attachment_progress` INTEGER, PRIMARY KEY(`id`, `subscriptionId`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subscriptionId",
+            "columnName": "subscriptionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceId",
+            "columnName": "sequenceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentType",
+            "columnName": "contentType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "encoding",
+            "columnName": "encoding",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationId",
+            "columnName": "notificationId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "3"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "click",
+            "columnName": "click",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actions",
+            "columnName": "actions",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percentage",
+            "columnName": "percentage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "end",
+            "columnName": "end",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon.url",
+            "columnName": "icon_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "icon.contentUri",
+            "columnName": "icon_contentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attachment.name",
+            "columnName": "attachment_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attachment.type",
+            "columnName": "attachment_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attachment.size",
+            "columnName": "attachment_size",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "attachment.expires",
+            "columnName": "attachment_expires",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "attachment.url",
+            "columnName": "attachment_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attachment.contentUri",
+            "columnName": "attachment_contentUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "attachment.progress",
+            "columnName": "attachment_progress",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "subscriptionId"
+          ]
+        }
+      },
+      {
+        "tableName": "User",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`baseUrl` TEXT NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, PRIMARY KEY(`baseUrl`))",
+        "fields": [
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "baseUrl"
+          ]
+        }
+      },
+      {
+        "tableName": "Log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `timestamp` INTEGER NOT NULL, `tag` TEXT NOT NULL, `level` INTEGER NOT NULL, `message` TEXT NOT NULL, `exception` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tag",
+            "columnName": "tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exception",
+            "columnName": "exception",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "CustomHeader",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`baseUrl` TEXT NOT NULL, `name` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`baseUrl`, `name`))",
+        "fields": [
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "baseUrl",
+            "name"
+          ]
+        }
+      },
+      {
+        "tableName": "TrustedCertificate",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`baseUrl` TEXT NOT NULL, `pem` TEXT NOT NULL, PRIMARY KEY(`baseUrl`))",
+        "fields": [
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pem",
+            "columnName": "pem",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "baseUrl"
+          ]
+        }
+      },
+      {
+        "tableName": "ClientCertificate",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`baseUrl` TEXT NOT NULL, `p12Base64` TEXT NOT NULL, `password` TEXT NOT NULL, PRIMARY KEY(`baseUrl`))",
+        "fields": [
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "p12Base64",
+            "columnName": "p12Base64",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "baseUrl"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '66bd8123b8636f494da9297ad4260d1d')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/> <!-- To reschedule the websocket retry -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/> <!-- As of Android 13, we need to ask for permission to post notifications -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/> <!-- Allows to ignore battery optimization without going to the settings -->
+    <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS"/> <!-- For live notifications with status chips (API 34+) -->
 
     <!-- UnifiedPush "raise to foreground" requirement, see https://unifiedpush.org/developers/spec/android/#service-to-raise-to-the-foreground -->
     <queries>

--- a/app/src/main/java/io/heckel/ntfy/db/Database.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Database.kt
@@ -160,6 +160,8 @@ data class Notification(
     @ColumnInfo(name = "actions") val actions: List<Action>?,
     @Embedded(prefix = "attachment_") val attachment: Attachment?,
     @ColumnInfo(name = "deleted") val deleted: Boolean,
+    @ColumnInfo(name = "percentage") val percentage: Int = -1, // 0-100 for live notifications, -1 means unset
+    @ColumnInfo(name = "end") val end: Long = 0, // Unix epoch for live countdown
     @Ignore val event: String = ApiService.EVENT_MESSAGE, // In-memory event type (message, message_delete, message_clear)
 ) {
     constructor(
@@ -178,10 +180,12 @@ data class Notification(
         icon: Icon?,
         actions: List<Action>?,
         attachment: Attachment?,
-        deleted: Boolean
+        deleted: Boolean,
+        percentage: Int = -1,
+        end: Long = 0
     ) : this(
         id, subscriptionId, timestamp, sequenceId, title, message, contentType, encoding,
-        notificationId, priority, tags, click, icon, actions, attachment, deleted, event = ApiService.EVENT_MESSAGE
+        notificationId, priority, tags, click, icon, actions, attachment, deleted, percentage, end, event = ApiService.EVENT_MESSAGE
     )
 }
 
@@ -299,7 +303,7 @@ data class LogEntry(
 }
 
 @androidx.room.Database(
-    version = 18,
+    version = 19,
     entities = [
         Subscription::class,
         Notification::class,
@@ -345,6 +349,7 @@ abstract class Database : RoomDatabase() {
                     .addMigrations(MIGRATION_15_16)
                     .addMigrations(MIGRATION_16_17)
                     .addMigrations(MIGRATION_17_18)
+                    .addMigrations(MIGRATION_18_19)
                     .fallbackToDestructiveMigration(true)
                     .build()
                 this.instance = instance
@@ -483,6 +488,24 @@ abstract class Database : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE Notification ADD COLUMN sequenceId TEXT NOT NULL DEFAULT ''")
                 db.execSQL("UPDATE Notification SET sequenceId = id WHERE sequenceId = ''")
+            }
+        }
+
+        private val MIGRATION_18_19 = object : Migration(18, 19) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                addColumnIfMissing(db, "ALTER TABLE Notification ADD COLUMN percentage INTEGER NOT NULL DEFAULT -1")
+                addColumnIfMissing(db, "ALTER TABLE Notification ADD COLUMN end INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
+        private fun addColumnIfMissing(db: SupportSQLiteDatabase, sql: String) {
+            try {
+                db.execSQL(sql)
+            } catch (e: android.database.sqlite.SQLiteException) {
+                val msg = e.message ?: ""
+                if (!msg.contains("duplicate column name", ignoreCase = true)) {
+                    throw e
+                }
             }
         }
     }

--- a/app/src/main/java/io/heckel/ntfy/db/Repository.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Repository.kt
@@ -404,6 +404,16 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
         }
     }
 
+    fun getLiveNotificationsEnabled(): Boolean {
+        return sharedPrefs.getBoolean(SHARED_PREFS_LIVE_NOTIFICATIONS_ENABLED, true) // Enabled by default
+    }
+
+    fun setLiveNotificationsEnabled(enabled: Boolean) {
+        sharedPrefs.edit {
+            putBoolean(SHARED_PREFS_LIVE_NOTIFICATIONS_ENABLED, enabled)
+        }
+    }
+
     fun getMessageBarEnabled(): Boolean {
         return sharedPrefs.getBoolean(SHARED_PREFS_MESSAGE_BAR_ENABLED, true) // Enabled by default
     }
@@ -652,8 +662,9 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
         const val SHARED_PREFS_BROADCAST_ENABLED = "BroadcastEnabled"
         const val SHARED_PREFS_UNIFIEDPUSH_ENABLED = "UnifiedPushEnabled"
         const val SHARED_PREFS_INSISTENT_MAX_PRIORITY_ENABLED = "InsistentMaxPriority"
-        const val SHARED_PREFS_RECORD_LOGS_ENABLED = "RecordLogs"
+		const val SHARED_PREFS_RECORD_LOGS_ENABLED = "RecordLogs"
         const val SHARED_PREFS_MESSAGE_BAR_ENABLED = "MessageBarEnabled"
+        const val SHARED_PREFS_LIVE_NOTIFICATIONS_ENABLED = "LiveNotificationsEnabled"
         const val SHARED_PREFS_BATTERY_OPTIMIZATIONS_REMIND_TIME = "BatteryOptimizationsRemindTime" // Timestamp as millis
         const val SHARED_PREFS_WEBSOCKET_REMIND_TIME = "JsonStreamRemindTime" // "Use WebSocket" banner (used to be JSON stream deprecation banner), timestamp as millis
         const val SHARED_PREFS_WEBSOCKET_RECONNECT_REMIND_TIME = "WebSocketReconnectRemindTime" // Timestamp as millis

--- a/app/src/main/java/io/heckel/ntfy/msg/Message.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/Message.kt
@@ -21,6 +21,8 @@ data class Message(
     val message: String?,
     @SerializedName("content_type") val contentType: String?,
     val encoding: String?,
+    @SerializedName("percentage") val percentage: Int?,
+    @SerializedName("end") val end: Long?,
     val attachment: MessageAttachment?,
 )
 

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationParser.kt
@@ -73,6 +73,8 @@ class NotificationParser {
             attachment = attachment,
             notificationId = deriveNotificationId(baseUrl, topic, sequenceId),
             deleted = false,
+			percentage = message.percentage ?: -1,
+            end = message.end ?: 0,
             event = message.event
         )
         return NotificationWithTopic(topic, notification)

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationService.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationService.kt
@@ -87,6 +87,34 @@ class NotificationService(val context: Context) {
         val channelId = toChannelId(groupId, notification.priority)
         val insistent = notification.priority == PRIORITY_MAX &&
                 (repository.getInsistentMaxPriorityEnabled() || subscription.insistent == Repository.INSISTENT_MAX_PRIORITY_ENABLED)
+
+        // Check for promoted live notification first
+        if (PromotedNotificationBuilder.shouldShowLiveNotification(
+                notification, context, repository.getLiveNotificationsEnabled()
+            )) {
+            val liveBuilder = PromotedNotificationBuilder.buildLiveNotification(subscription, notification, context, channelId)
+            if (liveBuilder != null) {
+                setStyleAndText(liveBuilder, subscription, notification)
+                setClickAction(liveBuilder, subscription, notification)
+                maybeSetDeleteIntent(liveBuilder, insistent)
+                maybeSetSound(liveBuilder, insistent, update)
+                maybeAddOpenAction(liveBuilder, notification)
+                maybeAddBrowseAction(liveBuilder, notification)
+                maybeAddDownloadAction(liveBuilder, notification)
+                maybeAddCancelAction(liveBuilder, notification)
+                maybeAddUserActions(liveBuilder, notification)
+
+                maybeCreateNotificationGroup(groupId, subscriptionGroupName(subscription))
+                maybeCreateNotificationChannel(groupId, notification.priority)
+                maybePlayInsistentSound(groupId, insistent)
+
+                Log.d(TAG, "Displaying promoted live notification $notification")
+                notificationManager.notify(notification.notificationId, liveBuilder.build())
+                return
+            }
+        }
+
+        // Regular notification path
         val builder = NotificationCompat.Builder(context, channelId)
             .setSmallIcon(R.drawable.ic_notification)
             .setColor(Colors.notificationIcon(context))

--- a/app/src/main/java/io/heckel/ntfy/msg/PromotedNotificationBuilder.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/PromotedNotificationBuilder.kt
@@ -1,0 +1,120 @@
+package io.heckel.ntfy.msg
+
+import android.content.Context
+import android.os.Build
+import android.os.Bundle
+import androidx.core.app.NotificationCompat
+import io.heckel.ntfy.R
+import io.heckel.ntfy.db.Notification
+import io.heckel.ntfy.db.Subscription
+import io.heckel.ntfy.ui.Colors
+import io.heckel.ntfy.util.formatTitle
+
+/**
+ * Builds promoted notifications for live update messages (percentage or countdown).
+ * Uses Android's Promoted Notification API (API 34+) to show status chips in the
+ * status bar. Uses the built-in Chronometer API for live countdown updates.
+ */
+object PromotedNotificationBuilder {
+
+    /**
+     * Determines whether this notification should be shown as a promoted live notification.
+     */
+    fun shouldShowLiveNotification(
+        notification: Notification,
+        context: Context,
+        liveNotificationsEnabled: Boolean
+    ): Boolean {
+        // Only on API 34+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            return false
+        }
+
+        // Setting must be enabled
+        if (!liveNotificationsEnabled) {
+            return false
+        }
+
+        // Must have percentage or end set
+        if (notification.percentage < 0 && notification.end <= 0) {
+            return false
+        }
+
+        // Mutually exclusive with download attachments
+        if (notification.attachment != null) {
+            return false
+        }
+
+        return true
+    }
+
+    /**
+     * Builds a promoted notification for live updates.
+     * Returns null if conditions aren't met (falls back to regular notification).
+     */
+	fun buildLiveNotification(
+		subscription: Subscription,
+		notification: Notification,
+		context: Context,
+		channelId: String
+	): NotificationCompat.Builder? {
+        if (!shouldShowLiveNotification(notification, context, true)) {
+            return null
+        }
+
+        val title = formatTitle(context.getString(R.string.app_base_url), subscription, notification)
+
+		val builder = NotificationCompat.Builder(context, channelId)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setColor(Colors.notificationIcon(context))
+            .setContentTitle(title)
+            .setContentText(notification.message ?: "")
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setAutoCancel(true)
+
+        // Chronometer MUST be set before setShowWhen() — matches Home Assistant order
+        if (notification.end > 0) {
+            val endMillis = if (notification.end > 1_000_000_000_000L) notification.end else notification.end * 1000
+            val remainingMillis = endMillis - System.currentTimeMillis()
+            builder.setWhen(endMillis)
+            builder.setUsesChronometer(true)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                // Fix for NPE on some OEMs (Home Assistant pattern)
+                builder.addExtras(Bundle())
+                builder.setChronometerCountDown(true)
+            }
+            // Auto-dismiss when countdown reaches 0 (prevents negative countdown)
+            if (remainingMillis > 0) {
+                builder.setTimeoutAfter(remainingMillis)
+            }
+        }
+
+        builder.setShowWhen(true)
+            .setRequestPromotedOngoing(true)
+
+        if (notification.percentage >= 0) {
+            builder.setShortCriticalText(buildStatusChipText(notification))
+        }
+
+        return builder
+    }
+
+    /**
+     * Builds the status chip text for the promoted notification.
+     * For countdown notifications, shows the initial countdown time.
+     * For percentage notifications, shows the percentage.
+     */
+    fun buildStatusChipText(notification: Notification): String {
+        // Percentage takes priority
+        if (notification.percentage >= 0) {
+            if (notification.percentage >= 100) {
+                return "Done"
+            }
+            return "${notification.percentage}%"
+        }
+
+        return ""
+    }
+
+}

--- a/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
@@ -257,6 +257,23 @@ class SettingsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPrefere
                 }
             }
 
+            // Live notifications (API 34+)
+            val liveNotificationsPrefId = context?.getString(R.string.settings_notifications_live_notifications_key) ?: return
+            val liveNotifications: SwitchPreferenceCompat? = findPreference(liveNotificationsPrefId)
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                liveNotifications?.isVisible = false
+            } else {
+                liveNotifications?.isChecked = repository.getLiveNotificationsEnabled()
+                liveNotifications?.preferenceDataStore = object : PreferenceDataStore() {
+                    override fun putBoolean(key: String?, value: Boolean) {
+                        repository.setLiveNotificationsEnabled(value)
+                    }
+                    override fun getBoolean(key: String?, defValue: Boolean): Boolean {
+                        return repository.getLiveNotificationsEnabled()
+                    }
+                }
+            }
+
             // Channel settings
             val channelPrefsPrefId = context?.getString(R.string.settings_notifications_channel_prefs_key) ?: return
             val channelPrefs: Preference? = findPreference(channelPrefsPrefId)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -377,6 +377,8 @@
     <string name="settings_notifications_insistent_max_priority_title">Keep alerting for highest priority</string>
     <string name="settings_notifications_insistent_max_priority_summary_enabled">Max priority notifications continuously alert until dismissed</string>
     <string name="settings_notifications_insistent_max_priority_summary_disabled">Max priority notifications only alert once</string>
+    <string name="settings_notifications_live_notifications_title">Live notifications</string>
+    <string name="settings_notifications_live_notifications_summary">Show countdown/progress as a live notification with status chip (Android 14+)</string>
     <string name="settings_general_header">General</string>
     <string name="settings_appearance_header">Appearance</string>
     <string name="settings_general_default_base_url_title">Default server</string>

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -19,6 +19,7 @@
     <string name="settings_notifications_auto_download_key" translatable="false">AutoDownload</string>
     <string name="settings_notifications_auto_delete_key" translatable="false">AutoDelete</string>
     <string name="settings_notifications_insistent_max_priority_key" translatable="false">InsistentMaxPriority</string>
+    <string name="settings_notifications_live_notifications_key" translatable="false">LiveNotificationsEnabled</string>
     <string name="settings_general_default_base_url_key" translatable="false">DefaultBaseURL</string>
     <string name="settings_general_users_key" translatable="false">ManageUsers</string>
     <string name="settings_general_dark_mode_key" translatable="false">DarkMode</string>

--- a/app/src/main/res/xml/main_preferences.xml
+++ b/app/src/main/res/xml/main_preferences.xml
@@ -29,6 +29,11 @@
                 app:key="@string/settings_notifications_insistent_max_priority_key"
                 app:title="@string/settings_notifications_insistent_max_priority_title"
                 app:defaultValue="false"/>
+        <SwitchPreferenceCompat
+                app:key="@string/settings_notifications_live_notifications_key"
+                app:title="@string/settings_notifications_live_notifications_title"
+                app:summary="@string/settings_notifications_live_notifications_summary"
+                app:defaultValue="true"/>
         <Preference
                 app:key="@string/settings_notifications_channel_prefs_key"
                 app:title="@string/settings_notifications_channel_prefs_title"

--- a/app/src/play/java/io/heckel/ntfy/firebase/FirebaseService.kt
+++ b/app/src/play/java/io/heckel/ntfy/firebase/FirebaseService.kt
@@ -163,6 +163,8 @@ class FirebaseService : FirebaseMessagingService() {
         val attachmentUrl = data["attachment_url"]
         val sequenceId = data["sequence_id"]
         val truncated = (data["truncated"] ?: "") == "1"
+		val percentage = data["percentage"]?.toIntOrNull() ?: -1
+        val end = data["end"]?.toLongOrNull() ?: 0
         if (id == null || topic == null || message == null || timestamp == null) {
             Log.d(TAG, "Discarding unexpected message: from=${remoteMessage.from}, fcmprio=${remoteMessage.priority}, fcmprio_orig=${remoteMessage.originalPriority}, data=${data}")
             return
@@ -208,6 +210,8 @@ class FirebaseService : FirebaseMessagingService() {
                 attachment = attachment,
                 notificationId = deriveNotificationId(baseUrl, topic, actualSequenceId),
                 deleted = false,
+                percentage = percentage,
+                end = end,
                 event = ApiService.EVENT_MESSAGE
             )
 


### PR DESCRIPTION
# Add Live Notification Support (Percentage Chips & Countdown)

This PR adds support for promoted live notifications on Android API 34+, displaying progress percentage chips and countdown timers in the status bar using Android's Promoted Notification API. From PR [1752](https://github.com/binwiederhier/ntfy/pull/1752) on ntfy

## What's New

- **Progress chips** — percentage values (`0%`–`100%`) shown as inline chips on the notification (`100` renders as `Done`)
- **Countdown timers** — `X-End` timestamps render as a live chronometer countdown
- **Settings toggle** — "Show live notifications" option in Settings (API 34+ only)
- **Promoted notifications** — uses `setRequestPromotedOngoing()` for status bar chips on supported devices

## Demo Video

https://github.com/user-attachments/assets/87f226d9-bbf0-4def-a982-0ef731f63aa3


## Changes

| File | Description |
|------|-------------|
| `db/Database.kt` | Migration 18→19: adds `percentage` (-1=unset) and `end` (0=unset) columns with duplicate-safe logic |
| `db/Database.kt` | Room schema snapshot `19.json` |
| `msg/Message.kt` | Added `percentage` and `end` fields to message model |
| `msg/NotificationParser.kt` | Parse `percentage`/`end` from incoming messages |
| `msg/PromotedNotificationBuilder.kt` | New: builds promoted notification with chronometer + chip text |
| `msg/NotificationService.kt` | Checks promoted path first, falls back to regular notification; applies parity click/delete/actions/sound |
| `db/Repository.kt` | Live notification setting key + getter |
| `ui/SettingsActivity.kt` | "Show live notifications" toggle (visible on API 34+) |
| `res/values/values.xml` | Settings key constant |
| `res/values/strings.xml` | Settings label + description strings |
| `res/xml/main_preferences.xml` | Settings preference entry |
| `AndroidManifest.xml` | `POST_PROMOTED_NOTIFICATIONS` permission (API 34+) |
| `play/java/.../FirebaseService.kt` | Parse `percentage`/`end` from FCM data payload |

## Validation

- Build: `./gradlew :app:assembleFdroidDebug` — passes
- Lint: `./gradlew :app:lintFdroidDebug` — passes
- Manual QA (all items passed per TESTING.md checklist as well as some others):
  - Subscribe to topic, send messages with tags/titles/priority
  - Main view: multi-delete, global mute toggle
  - Detail view: per-topic mute, instant toggle, clear notifications
  - **New**: Live countdown renders chronometer correctly
  - **New**: Percentage chips update in-place (`0%`, `50%`, `100%` → "Done")
  - **New**: Settings toggle hides/shows live notifications
  - **New**: Non-live notifications unchanged

## Notes

> **Kotlin note**: This is my first time working extensively with Kotlin, so the code may benefit from review by someone more experienced with the language and Android conventions. The core behavior works end-to-end as validated above, but I'd welcome any feedback.

- Default `percentage = -1` (unset) to distinguish absent from explicit zero
- Default `end = 0` (unset) — non-zero values trigger chronometer display
- Promoted path is a pre-check; if conditions aren't met, falls back to regular notification
- `setRequestPromotedOngoing()` used per Android API 34+ Promoted Notification spec