### PR TITLE
Fix failed_reason extra

### DIFF
--- a/app/src/main/java/io/heckel/ntfy/up/Distributor.kt
+++ b/app/src/main/java/io/heckel/ntfy/up/Distributor.kt
@@ -43,7 +43,7 @@ class Distributor(val context: Context) {
         broadcastIntent.`package` = app
         broadcastIntent.action = ACTION_REGISTRATION_FAILED
         broadcastIntent.putExtra(EXTRA_TOKEN, connectorToken)
-        broadcastIntent.putExtra(EXTRA_FAILED_REASON, reason)
+        broadcastIntent.putExtra(EXTRA_FAILED_REASON, reason.name)
         context.sendBroadcast(broadcastIntent)
     }
 


### PR DESCRIPTION
We were previously sending the enum directly, but it needs to be a String.
It caused an exception for receiving apps which try to `getStringExtra` on the intent.

This is a bug I introduced here, with this PR: https://github.com/binwiederhier/ntfy-android/pull/98/changes#diff-cfdf8f39a4877606b81575e4a31165e684666e770373ea0e061fa68920fec876R44