### PR TITLE
Download Retries and Optional Notification items

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
         targetSdkVersion 36
 
         versionCode 63
-        versionName "1.25.2.jws"
+        versionName "1.25.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
         targetSdkVersion 36
 
         versionCode 63
-        versionName "1.25.2"
+        versionName "1.25.2.jws"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/io/heckel/ntfy/backup/Backuper.kt
+++ b/app/src/main/java/io/heckel/ntfy/backup/Backuper.kt
@@ -121,6 +121,9 @@ class Backuper(val context: Context) {
                     upAppId = s.upAppId,
                     upConnectorToken = s.upConnectorToken,
                     displayName = s.displayName,
+                    addAttachment = s.addAttachment ?: Repository.ADD_ATTACHMENT_USE_GLOBAL,
+                    downloadProgress = s.downloadProgress ?: Repository.DOWNLOAD_PROGRESS_USE_GLOBAL,
+                    waitForAttachment = s.waitForAttachment ?: Repository.WAIT_FOR_ATTACHMENT_USE_GLOBAL,
                 )
                 repository.addSubscription(subscription)
 
@@ -302,7 +305,10 @@ class Backuper(val context: Context) {
                 icon = s.icon,
                 upAppId = s.upAppId,
                 upConnectorToken = s.upConnectorToken,
-                displayName = s.displayName
+                displayName = s.displayName,
+                addAttachment = s.addAttachment,
+                downloadProgress = s.downloadProgress,
+                waitForAttachment = s.waitForAttachment
             )
         }
     }
@@ -443,7 +449,10 @@ data class Subscription(
     val icon: String?,
     val upAppId: String?,
     val upConnectorToken: String?,
-    val displayName: String?
+    val displayName: String?,
+    val addAttachment: Int?,
+    val downloadProgress: Int?,
+    val waitForAttachment: Int?
 )
 
 data class Notification(

--- a/app/src/main/java/io/heckel/ntfy/db/Database.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Database.kt
@@ -44,6 +44,9 @@ data class Subscription(
     @ColumnInfo(name = "upConnectorToken") val upConnectorToken: String?, // UnifiedPush connector token
     @ColumnInfo(name = "displayName") val displayName: String?,
     @ColumnInfo(name = "dedicatedChannels") val dedicatedChannels: Boolean,
+    @ColumnInfo(name = "addAttachment") val addAttachment: Int,
+    @ColumnInfo(name = "downloadProgress") val downloadProgress: Int,
+    @ColumnInfo(name = "waitForAttachment") val waitForAttachment: Int,
     @Ignore val totalCount: Int = 0, // Total notifications
     @Ignore val newCount: Int = 0, // New notifications
     @Ignore val lastActive: Long = 0, // Unix timestamp
@@ -63,7 +66,10 @@ data class Subscription(
         upAppId: String,
         upConnectorToken: String,
         displayName: String?,
-        dedicatedChannels: Boolean
+        dedicatedChannels: Boolean,
+        addAttachment: Int,
+        downloadProgress: Int,
+        waitForAttachment: Int
     ) :
             this(
                 id,
@@ -80,6 +86,9 @@ data class Subscription(
                 upConnectorToken,
                 displayName,
                 dedicatedChannels,
+                addAttachment,
+                downloadProgress,
+                waitForAttachment,
                 totalCount = 0,
                 newCount = 0,
                 lastActive = 0,
@@ -137,6 +146,9 @@ data class SubscriptionWithMetadata(
     val upConnectorToken: String?,
     val displayName: String?,
     val dedicatedChannels: Boolean,
+    val addAttachment: Int,
+    val downloadProgress: Int,
+    val waitForAttachment: Int,
     val totalCount: Int,
     val newCount: Int,
     val lastActive: Long
@@ -299,7 +311,7 @@ data class LogEntry(
 }
 
 @androidx.room.Database(
-    version = 18,
+    version = 19,
     entities = [
         Subscription::class,
         Notification::class,
@@ -345,6 +357,7 @@ abstract class Database : RoomDatabase() {
                     .addMigrations(MIGRATION_15_16)
                     .addMigrations(MIGRATION_16_17)
                     .addMigrations(MIGRATION_17_18)
+                    .addMigrations(MIGRATION_18_19)
                     .fallbackToDestructiveMigration(true)
                     .build()
                 this.instance = instance
@@ -485,6 +498,14 @@ abstract class Database : RoomDatabase() {
                 db.execSQL("UPDATE Notification SET sequenceId = id WHERE sequenceId = ''")
             }
         }
+
+        private val MIGRATION_18_19 = object : Migration(18, 19) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE Subscription ADD COLUMN addAttachment INTEGER NOT NULL DEFAULT (-1)")
+                db.execSQL("ALTER TABLE Subscription ADD COLUMN downloadProgress INTEGER NOT NULL DEFAULT (-1)")
+                db.execSQL("ALTER TABLE Subscription ADD COLUMN waitForAttachment INTEGER NOT NULL DEFAULT (-1)")
+            }
+        }
     }
 }
 
@@ -492,7 +513,7 @@ abstract class Database : RoomDatabase() {
 interface SubscriptionDao {
     @Query("""
         SELECT 
-          s.id, s.baseUrl, s.topic, s.instant, s.mutedUntil, s.minPriority, s.autoDelete, s.insistent, s.lastNotificationId, s.icon, s.upAppId, s.upConnectorToken, s.displayName, s.dedicatedChannels,
+          s.id, s.baseUrl, s.topic, s.instant, s.mutedUntil, s.minPriority, s.autoDelete, s.insistent, s.lastNotificationId, s.icon, s.upAppId, s.upConnectorToken, s.displayName, s.dedicatedChannels, s.addAttachment, s.downloadProgress, s.waitForAttachment,
           COUNT(n.id) totalCount, 
           COUNT(CASE n.notificationId WHEN 0 THEN NULL ELSE n.id END) newCount, 
           IFNULL(MAX(n.timestamp),0) AS lastActive
@@ -505,7 +526,7 @@ interface SubscriptionDao {
 
     @Query("""
         SELECT 
-          s.id, s.baseUrl, s.topic, s.instant, s.mutedUntil, s.minPriority, s.autoDelete, s.insistent, s.lastNotificationId, s.icon, s.upAppId, s.upConnectorToken, s.displayName, s.dedicatedChannels,
+          s.id, s.baseUrl, s.topic, s.instant, s.mutedUntil, s.minPriority, s.autoDelete, s.insistent, s.lastNotificationId, s.icon, s.upAppId, s.upConnectorToken, s.displayName, s.dedicatedChannels, s.addAttachment, s.downloadProgress, s.waitForAttachment,
           COUNT(n.id) totalCount, 
           COUNT(CASE n.notificationId WHEN 0 THEN NULL ELSE n.id END) newCount, 
           IFNULL(MAX(n.timestamp),0) AS lastActive
@@ -518,7 +539,7 @@ interface SubscriptionDao {
 
     @Query("""
         SELECT 
-          s.id, s.baseUrl, s.topic, s.instant, s.mutedUntil, s.minPriority, s.autoDelete, s.insistent, s.lastNotificationId, s.icon, s.upAppId, s.upConnectorToken, s.displayName, s.dedicatedChannels,
+          s.id, s.baseUrl, s.topic, s.instant, s.mutedUntil, s.minPriority, s.autoDelete, s.insistent, s.lastNotificationId, s.icon, s.upAppId, s.upConnectorToken, s.displayName, s.dedicatedChannels, s.addAttachment, s.downloadProgress, s.waitForAttachment,
           COUNT(n.id) totalCount, 
           COUNT(CASE n.notificationId WHEN 0 THEN NULL ELSE n.id END) newCount, 
           IFNULL(MAX(n.timestamp),0) AS lastActive
@@ -531,7 +552,7 @@ interface SubscriptionDao {
 
     @Query("""
         SELECT 
-          s.id, s.baseUrl, s.topic, s.instant, s.mutedUntil, s.minPriority, s.autoDelete, s.insistent, s.lastNotificationId, s.icon, s.upAppId, s.upConnectorToken, s.displayName, s.dedicatedChannels,
+          s.id, s.baseUrl, s.topic, s.instant, s.mutedUntil, s.minPriority, s.autoDelete, s.insistent, s.lastNotificationId, s.icon, s.upAppId, s.upConnectorToken, s.displayName, s.dedicatedChannels, s.addAttachment, s.downloadProgress, s.waitForAttachment,
           COUNT(n.id) totalCount, 
           COUNT(CASE n.notificationId WHEN 0 THEN NULL ELSE n.id END) newCount, 
           IFNULL(MAX(n.timestamp),0) AS lastActive
@@ -544,7 +565,7 @@ interface SubscriptionDao {
 
     @Query("""
         SELECT 
-          s.id, s.baseUrl, s.topic, s.instant, s.mutedUntil, s.minPriority, s.autoDelete, s.insistent, s.lastNotificationId, s.icon, s.upAppId, s.upConnectorToken, s.displayName, s.dedicatedChannels,
+          s.id, s.baseUrl, s.topic, s.instant, s.mutedUntil, s.minPriority, s.autoDelete, s.insistent, s.lastNotificationId, s.icon, s.upAppId, s.upConnectorToken, s.displayName, s.dedicatedChannels, s.addAttachment, s.downloadProgress, s.waitForAttachment,
           COUNT(n.id) totalCount, 
           COUNT(CASE n.notificationId WHEN 0 THEN NULL ELSE n.id END) newCount, 
           IFNULL(MAX(n.timestamp),0) AS lastActive

--- a/app/src/main/java/io/heckel/ntfy/db/Repository.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Repository.kt
@@ -394,6 +394,36 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
         }
     }
 
+    fun getAddAttachmentEnabled(): Boolean {
+        return sharedPrefs.getBoolean(SHARED_PREFS_ADD_ATTACHMENT_ENABLED, true) // Enabled by default
+    }
+
+    fun setAddAttachmentEnabled(enabled: Boolean) {
+        sharedPrefs.edit {
+            putBoolean(SHARED_PREFS_ADD_ATTACHMENT_ENABLED, enabled)
+        }
+    }
+
+    fun getDownloadProgressEnabled(): Boolean {
+        return sharedPrefs.getBoolean(SHARED_PREFS_DOWNLOAD_PROGRESS_ENABLED, true) // Enabled by default
+    }
+
+    fun setDownloadProgressEnabled(enabled: Boolean) {
+        sharedPrefs.edit {
+            putBoolean(SHARED_PREFS_DOWNLOAD_PROGRESS_ENABLED, enabled)
+        }
+    }
+
+    fun getWaitForAttachmentEnabled(): Boolean {
+        return sharedPrefs.getBoolean(SHARED_PREFS_WAIT_FOR_ATTACHMENT_ENABLED, false) // Disabled by default
+    }
+
+    fun setWaitForAttachmentEnabled(enabled: Boolean) {
+        sharedPrefs.edit {
+            putBoolean(SHARED_PREFS_WAIT_FOR_ATTACHMENT_ENABLED, enabled)
+        }
+    }
+
     fun getRecordLogs(): Boolean {
         return sharedPrefs.getBoolean(SHARED_PREFS_RECORD_LOGS_ENABLED, false) // Disabled by default
     }
@@ -656,6 +686,9 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
         const val SHARED_PREFS_BROADCAST_ENABLED = "BroadcastEnabled"
         const val SHARED_PREFS_UNIFIEDPUSH_ENABLED = "UnifiedPushEnabled"
         const val SHARED_PREFS_INSISTENT_MAX_PRIORITY_ENABLED = "InsistentMaxPriority"
+        const val SHARED_PREFS_ADD_ATTACHMENT_ENABLED = "AddAttachment"
+        const val SHARED_PREFS_DOWNLOAD_PROGRESS_ENABLED = "DownloadProgress"
+        const val SHARED_PREFS_WAIT_FOR_ATTACHMENT_ENABLED = "WaitForAttachment"
         const val SHARED_PREFS_RECORD_LOGS_ENABLED = "RecordLogs"
         const val SHARED_PREFS_MESSAGE_BAR_ENABLED = "MessageBarEnabled"
         const val SHARED_PREFS_BATTERY_OPTIMIZATIONS_REMIND_TIME = "BatteryOptimizationsRemindTime" // Timestamp as millis

--- a/app/src/main/java/io/heckel/ntfy/db/Repository.kt
+++ b/app/src/main/java/io/heckel/ntfy/db/Repository.kt
@@ -591,6 +591,9 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
                 upAppId = s.upAppId,
                 upConnectorToken = s.upConnectorToken,
                 displayName = s.displayName,
+                addAttachment = s.addAttachment,
+                downloadProgress = s.downloadProgress,
+                waitForAttachment = s.waitForAttachment,
                 totalCount = s.totalCount,
                 newCount = s.newCount,
                 lastActive = s.lastActive,
@@ -618,6 +621,9 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
             upAppId = s.upAppId,
             upConnectorToken = s.upConnectorToken,
             displayName = s.displayName,
+            addAttachment = s.addAttachment,
+            downloadProgress = s.downloadProgress,
+            waitForAttachment = s.waitForAttachment,
             totalCount = s.totalCount,
             newCount = s.newCount,
             lastActive = s.lastActive,
@@ -704,6 +710,18 @@ class Repository(private val sharedPrefs: SharedPreferences, database: Database)
 
         const val MIN_PRIORITY_USE_GLOBAL = 0
         const val MIN_PRIORITY_ANY = 1
+
+        const val ADD_ATTACHMENT_USE_GLOBAL = -1
+        const val ADD_ATTACHMENT_OFF = 0
+        const val ADD_ATTACHMENT_ON = 1
+
+        const val DOWNLOAD_PROGRESS_USE_GLOBAL = -1
+        const val DOWNLOAD_PROGRESS_OFF = 0
+        const val DOWNLOAD_PROGRESS_ON = 1
+
+        const val WAIT_FOR_ATTACHMENT_USE_GLOBAL = -1
+        const val WAIT_FOR_ATTACHMENT_OFF = 0
+        const val WAIT_FOR_ATTACHMENT_ON = 1
 
         const val MUTED_UNTIL_SHOW_ALL = 0L
         const val MUTED_UNTIL_FOREVER = 1L

--- a/app/src/main/java/io/heckel/ntfy/msg/DownloadAttachmentWorker.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/DownloadAttachmentWorker.kt
@@ -48,86 +48,80 @@ class DownloadAttachmentWorker(private val context: Context, params: WorkerParam
         attachment = notification.attachment ?: return Result.failure()
         try {
             downloadAttachment(userAction)
+            return Result.success()
         } catch (e: CancellationException) {
             Log.d(TAG, "Attachment download was canceled")
             maybeDeleteFile()
             throw e // We must re-throw this to stop the worker
         } catch (e: Exception) {
+            if (runAttemptCount < MAX_RETRIES) {
+                Log.w(TAG, "Attachment download failed (attempt $runAttemptCount), retrying ...", e)
+                return Result.retry()
+            } else {
                 failed(e)
+                return Result.failure()
+            }
         }
-        return Result.success()
     }
 
     private suspend fun downloadAttachment(userAction: Boolean) {
         Log.d(TAG, "Downloading attachment from ${attachment.url}")
 
-        try {
-            val user = repository.getUser(extractBaseUrl(attachment.url))
-            val customHeaders = repository.getCustomHeaders(extractBaseUrl(attachment.url))
-            val request = HttpUtil.requestBuilder(attachment.url, user, customHeaders).build()
-            val client = HttpUtil.longCallClient(context, extractBaseUrl(attachment.url))
-            client.newCall(request).execute().use { response ->
-                Log.d(TAG, "Download: headers received: $response")
-                if (!response.isSuccessful) {
-                    throw Exception("Unexpected response: ${response.code}")
-                }
-                save(updateAttachmentFromResponse(response))
-                if (!userAction && shouldAbortDownload()) {
-                    Log.d(TAG, "Aborting download: Content-Length is larger than auto-download setting")
-                    return
-                }
-                val resolver = applicationContext.contentResolver
-                val uri = createUri(notification)
-                this.uri = uri // Required for cleanup in onStopped()
-
-                Log.d(TAG, "Starting download to content URI: $uri")
-                var bytesCopied: Long = 0
-                val outFile = resolver.openOutputStream(uri) ?: throw Exception("Cannot open output stream")
-                val downloadLimit = getDownloadLimit(userAction)
-                outFile.use { fileOut ->
-                    val fileIn = response.body.byteStream()
-                    val buffer = ByteArray(BUFFER_SIZE)
-                    var bytes = fileIn.read(buffer)
-                    var lastProgress = 0L
-                    while (bytes >= 0) {
-                        if (System.currentTimeMillis() - lastProgress > NOTIFICATION_UPDATE_INTERVAL_MILLIS) {
-                            if (isStopped) { // Canceled by user
-                                save(attachment.copy(progress = ATTACHMENT_PROGRESS_NONE))
-                                return // File will be deleted in onStopped()
-                            }
-                            val progress = if (attachment.size != null && attachment.size!! > 0) {
-                                (bytesCopied.toFloat()/attachment.size!!.toFloat()*100).toInt()
-                            } else {
-                                ATTACHMENT_PROGRESS_INDETERMINATE
-                            }
-                            save(attachment.copy(progress = progress))
-                            lastProgress = System.currentTimeMillis()
-                        }
-                        if (downloadLimit != null && bytesCopied > downloadLimit) {
-                            throw Exception("Attachment is longer than max download size.")
-                        }
-                        fileOut.write(buffer, 0, bytes)
-                        bytesCopied += bytes
-                        bytes = fileIn.read(buffer)
-                    }
-                }
-                Log.d(TAG, "Attachment download: successful response, proceeding with download")
-                save(attachment.copy(
-                    size = bytesCopied,
-                    contentUri = uri.toString(),
-                    progress = ATTACHMENT_PROGRESS_DONE
-                ))
+        val user = repository.getUser(extractBaseUrl(attachment.url))
+        val customHeaders = repository.getCustomHeaders(extractBaseUrl(attachment.url))
+        val request = HttpUtil.requestBuilder(attachment.url, user, customHeaders).build()
+        val client = HttpUtil.longCallClient(context, extractBaseUrl(attachment.url))
+        client.newCall(request).execute().use { response ->
+            Log.d(TAG, "Download: headers received: $response")
+            if (!response.isSuccessful) {
+                throw Exception("Unexpected response: ${response.code}")
             }
-        } catch (e: Exception) {
-            failed(e)
+            save(updateAttachmentFromResponse(response))
+            if (!userAction && shouldAbortDownload()) {
+                Log.d(TAG, "Aborting download: Content-Length is larger than auto-download setting")
+                return
+            }
+            val resolver = applicationContext.contentResolver
+            val uri = createUri(notification)
+            this.uri = uri // Required for cleanup in onStopped()
 
-            // Toast in a Worker: https://stackoverflow.com/a/56428145/1440785
-            val handler = Handler(Looper.getMainLooper())
-            handler.postDelayed({
-                Toast
-                    .makeText(context, context.getString(R.string.detail_item_download_failed, e.message), Toast.LENGTH_LONG)
-                    .show()
-            }, 200)
+            Log.d(TAG, "Starting download to content URI: $uri")
+            var bytesCopied: Long = 0
+            val outFile = resolver.openOutputStream(uri) ?: throw Exception("Cannot open output stream")
+            val downloadLimit = getDownloadLimit(userAction)
+            outFile.use { fileOut ->
+                val fileIn = response.body.byteStream()
+                val buffer = ByteArray(BUFFER_SIZE)
+                var bytes = fileIn.read(buffer)
+                var lastProgress = 0L
+                while (bytes >= 0) {
+                    if (System.currentTimeMillis() - lastProgress > NOTIFICATION_UPDATE_INTERVAL_MILLIS) {
+                        if (isStopped) { // Canceled by user
+                            save(attachment.copy(progress = ATTACHMENT_PROGRESS_NONE))
+                            return // File will be deleted in onStopped()
+                        }
+                        val progress = if (attachment.size != null && attachment.size!! > 0) {
+                            (bytesCopied.toFloat()/attachment.size!!.toFloat()*100).toInt()
+                        } else {
+                            ATTACHMENT_PROGRESS_INDETERMINATE
+                        }
+                        save(attachment.copy(progress = progress))
+                        lastProgress = System.currentTimeMillis()
+                    }
+                    if (downloadLimit != null && bytesCopied > downloadLimit) {
+                        throw Exception("Attachment is longer than max download size.")
+                    }
+                    fileOut.write(buffer, 0, bytes)
+                    bytesCopied += bytes
+                    bytes = fileIn.read(buffer)
+                }
+            }
+            Log.d(TAG, "Attachment download: successful response, proceeding with download")
+            save(attachment.copy(
+                size = bytesCopied,
+                contentUri = uri.toString(),
+                progress = ATTACHMENT_PROGRESS_DONE
+            ))
         }
     }
 
@@ -214,5 +208,6 @@ class DownloadAttachmentWorker(private val context: Context, params: WorkerParam
         private const val ATTACHMENT_CACHE_DIR = "attachments"
         private const val BUFFER_SIZE = 8 * 1024
         private const val NOTIFICATION_UPDATE_INTERVAL_MILLIS = 800
+        private const val MAX_RETRIES = 11
     }
 }

--- a/app/src/main/java/io/heckel/ntfy/msg/DownloadAttachmentWorker.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/DownloadAttachmentWorker.kt
@@ -26,6 +26,7 @@ import io.heckel.ntfy.util.ensureSafeNewFile
 import io.heckel.ntfy.util.extractBaseUrl
 import okhttp3.Response
 import java.io.File
+import java.lang.Thread.sleep
 import kotlin.coroutines.cancellation.CancellationException
 
 class DownloadAttachmentWorker(private val context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
@@ -52,7 +53,7 @@ class DownloadAttachmentWorker(private val context: Context, params: WorkerParam
             maybeDeleteFile()
             throw e // We must re-throw this to stop the worker
         } catch (e: Exception) {
-            failed(e)
+                failed(e)
         }
         return Result.success()
     }

--- a/app/src/main/java/io/heckel/ntfy/msg/DownloadManager.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/DownloadManager.kt
@@ -1,11 +1,13 @@
 package io.heckel.ntfy.msg
 
 import android.content.Context
+import androidx.work.BackoffPolicy
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import androidx.work.workDataOf
 import io.heckel.ntfy.util.Log
+import java.util.concurrent.TimeUnit
 
 /**
  * Download attachment in the background via WorkManager
@@ -18,6 +20,7 @@ object DownloadManager {
     private const val DOWNLOAD_WORK_ATTACHMENT_NAME_PREFIX = "io.heckel.ntfy.DOWNLOAD_FILE_"
     private const val DOWNLOAD_WORK_ICON_NAME_PREFIX = "io.heckel.ntfy.DOWNLOAD_ICON_"
     private const val DOWNLOAD_WORK_BOTH_NAME_PREFIX = "io.heckel.ntfy.DOWNLOAD_BOTH_"
+    private const val INITIAL_BACKOFF_DELAY_SECONDS = 5L
 
     fun enqueue(context: Context, notificationId: String, userAction: Boolean, type: DownloadType) {
         when (type) {
@@ -36,6 +39,7 @@ object DownloadManager {
                 DownloadAttachmentWorker.INPUT_DATA_ID to notificationId,
                 DownloadAttachmentWorker.INPUT_DATA_USER_ACTION to userAction
             ))
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, INITIAL_BACKOFF_DELAY_SECONDS, TimeUnit.SECONDS)
             .build()
         workManager.enqueueUniqueWork(workName, ExistingWorkPolicy.KEEP, workRequest)
     }
@@ -60,6 +64,7 @@ object DownloadManager {
                 DownloadAttachmentWorker.INPUT_DATA_ID to notificationId,
                 DownloadAttachmentWorker.INPUT_DATA_USER_ACTION to userAction
             ))
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, INITIAL_BACKOFF_DELAY_SECONDS, TimeUnit.SECONDS)
             .build()
         val iconWorkRequest = OneTimeWorkRequest.Builder(DownloadIconWorker::class.java)
             .setInputData(workDataOf(

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationDispatcher.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationDispatcher.kt
@@ -34,7 +34,8 @@ class NotificationDispatcher(val context: Context, val repository: Repository) {
         if (cancel) {
             notifier.cancel(notification.notificationId)
         } else if (notify) {
-            val wait = downloadAttachment && repository.getWaitForAttachmentEnabled()
+            val waitForAttachment = if (subscription.waitForAttachment == Repository.WAIT_FOR_ATTACHMENT_USE_GLOBAL) repository.getWaitForAttachmentEnabled() else subscription.waitForAttachment == Repository.WAIT_FOR_ATTACHMENT_ON
+            val wait = downloadAttachment && waitForAttachment
             if (!wait) {
                 notifier.display(subscription, notification)
             }

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationDispatcher.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationDispatcher.kt
@@ -26,8 +26,7 @@ class NotificationDispatcher(val context: Context, val repository: Repository) {
         Log.d(TAG, "Dispatching $notification for subscription $subscription")
 
         val cancel = shouldCancel(notification)
-        val muted = getMuted(subscription)
-        val notify = shouldNotify(subscription, notification, muted)
+        val notify = notifier.shouldNotify(subscription, notification)
         val broadcast = shouldBroadcast(subscription, notification)
         val distribute = shouldDistribute(subscription, notification)
         val downloadAttachment = shouldDownloadAttachment(notification)
@@ -35,9 +34,13 @@ class NotificationDispatcher(val context: Context, val repository: Repository) {
         if (cancel) {
             notifier.cancel(notification.notificationId)
         } else if (notify) {
-            notifier.display(subscription, notification)
+            val wait = downloadAttachment && repository.getWaitForAttachmentEnabled()
+            if (!wait) {
+                notifier.display(subscription, notification)
+            }
         }
         if (broadcast) {
+            val muted = getMuted(subscription)
             broadcaster.sendMessage(subscription, notification, muted)
         }
         if (distribute) {
@@ -80,19 +83,6 @@ class NotificationDispatcher(val context: Context, val repository: Repository) {
 
     private fun shouldCancel(notification: Notification): Boolean {
         return notification.event == ApiService.EVENT_MESSAGE_CLEAR || notification.event == ApiService.EVENT_MESSAGE_DELETE
-    }
-
-    private fun shouldNotify(subscription: Subscription, notification: Notification, muted: Boolean): Boolean {
-        if (subscription.upAppId != null || notification.event != ApiService.EVENT_MESSAGE) {
-            return false
-        }
-        val priority = if (notification.priority > 0) notification.priority else 3
-        val minPriority = if (subscription.minPriority > 0) subscription.minPriority else repository.getMinPriority()
-        if (priority < minPriority) {
-            return false
-        }
-        val detailsVisible = repository.detailViewSubscriptionId.get() == notification.subscriptionId
-        return !detailsVisible && !muted
     }
 
     private fun shouldBroadcast(subscription: Subscription, notification: Notification): Boolean {

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationService.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationService.kt
@@ -123,10 +123,10 @@ class NotificationService(val context: Context) {
         setClickAction(builder, subscription, notification)
         maybeSetDeleteIntent(builder, insistent)
         maybeSetSound(builder, insistent, update)
-        maybeSetProgress(builder, notification)
-        maybeAddOpenAction(builder, notification)
-        maybeAddBrowseAction(builder, notification)
         if (repository.getAddAttachmentEnabled()) {
+            maybeSetProgress(builder, notification)
+            maybeAddOpenAction(builder, notification)
+            maybeAddBrowseAction(builder, notification)
             setStyleAndText(builder, subscription, notification) // Preview picture or big text style
             maybeAddDownloadAction(builder, notification)
             maybeAddCancelAction(builder, notification)

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationService.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationService.kt
@@ -36,10 +36,8 @@ class NotificationService(val context: Context) {
 
     fun update(subscription: Subscription, notification: Notification) {
         val active = notificationManager.activeNotifications.find { it.id == notification.notificationId } != null
-        if (active) {
             Log.d(TAG, "Updating notification $notification")
             displayInternal(subscription, notification, update = true)
-        }
     }
 
     fun cancel(notification: Notification) {
@@ -82,6 +80,9 @@ class NotificationService(val context: Context) {
     }
 
     private fun displayInternal(subscription: Subscription, notification: Notification, update: Boolean = false) {
+        if (update) {
+            return;
+        }
         val title = formatTitle(appBaseUrl, subscription, notification)
         val groupId = if (subscription.dedicatedChannels) subscriptionGroupId(subscription) else DEFAULT_GROUP
         val channelId = toChannelId(groupId, notification.priority)
@@ -95,21 +96,26 @@ class NotificationService(val context: Context) {
             .setShowWhen(true)
             .setOnlyAlertOnce(true) // Do not vibrate or play sound if already showing (updates!)
             .setAutoCancel(true) // Cancel when notification is clicked
-        setStyleAndText(builder, subscription, notification) // Preview picture or big text style
+//        setStyleAndText(builder, subscription, notification) // Preview picture or big text style
         setClickAction(builder, subscription, notification)
         maybeSetDeleteIntent(builder, insistent)
         maybeSetSound(builder, insistent, update)
         maybeSetProgress(builder, notification)
         maybeAddOpenAction(builder, notification)
         maybeAddBrowseAction(builder, notification)
-        maybeAddDownloadAction(builder, notification)
-        maybeAddCancelAction(builder, notification)
+//        maybeAddDownloadAction(builder, notification)
+//        maybeAddCancelAction(builder, notification)
         maybeAddUserActions(builder, notification)
 
         maybeCreateNotificationGroup(groupId, subscriptionGroupName(subscription))
         maybeCreateNotificationChannel(groupId, notification.priority)
         maybePlayInsistentSound(groupId, insistent)
 
+//        val hasAttach = if (notification.attachment != null) true else false
+//        val attachReady = if ((hasAttach) && (notification.attachment?.progress == ATTACHMENT_PROGRESS_DONE)) true else false
+//        if (hasAttach and !attachReady) {
+//            return
+//        }
         notificationManager.notify(notification.notificationId, builder.build())
     }
 
@@ -130,6 +136,7 @@ class NotificationService(val context: Context) {
             builder.setSound(defaultSoundUri)
         } else {
             builder.setSound(null)
+            builder.setVibrate(null);
         }
     }
 

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationService.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationService.kt
@@ -36,8 +36,21 @@ class NotificationService(val context: Context) {
 
     fun update(subscription: Subscription, notification: Notification) {
         val active = notificationManager.activeNotifications.find { it.id == notification.notificationId } != null
+        if (active) {
+            val progress = notification.attachment?.progress
+            if (progress != null && progress in 0..99 && !repository.getDownloadProgressEnabled()) {
+                return // Progress update, but disabled
+            }
             Log.d(TAG, "Updating notification $notification")
             displayInternal(subscription, notification, update = true)
+        } else {
+            val progress = notification.attachment?.progress
+            val finished = progress == ATTACHMENT_PROGRESS_DONE || progress == ATTACHMENT_PROGRESS_FAILED
+            if (finished && repository.getWaitForAttachmentEnabled() && shouldNotify(subscription, notification)) {
+                Log.d(TAG, "Displaying deferred notification $notification")
+                displayInternal(subscription, notification)
+            }
+        }
     }
 
     fun cancel(notification: Notification) {
@@ -52,6 +65,20 @@ class NotificationService(val context: Context) {
             Log.d(TAG, "Cancelling notification $notificationId")
             notificationManager.cancel(notificationId)
         }
+    }
+
+    fun shouldNotify(subscription: Subscription, notification: Notification): Boolean {
+        if (subscription.upAppId != null || notification.event != ApiService.EVENT_MESSAGE) {
+            return false
+        }
+        val priority = if (notification.priority > 0) notification.priority else 3
+        val minPriority = if (subscription.minPriority > 0) subscription.minPriority else repository.getMinPriority()
+        if (priority < minPriority) {
+            return false
+        }
+        val muted = repository.isGlobalMuted() || subscription.mutedUntil == 1L || (subscription.mutedUntil > 1L && subscription.mutedUntil > System.currentTimeMillis()/1000)
+        val detailsVisible = repository.detailViewSubscriptionId.get() == notification.subscriptionId
+        return !detailsVisible && !muted
     }
 
     fun createDefaultNotificationChannels() {
@@ -80,9 +107,6 @@ class NotificationService(val context: Context) {
     }
 
     private fun displayInternal(subscription: Subscription, notification: Notification, update: Boolean = false) {
-        if (update) {
-            return;
-        }
         val title = formatTitle(appBaseUrl, subscription, notification)
         val groupId = if (subscription.dedicatedChannels) subscriptionGroupId(subscription) else DEFAULT_GROUP
         val channelId = toChannelId(groupId, notification.priority)
@@ -96,26 +120,21 @@ class NotificationService(val context: Context) {
             .setShowWhen(true)
             .setOnlyAlertOnce(true) // Do not vibrate or play sound if already showing (updates!)
             .setAutoCancel(true) // Cancel when notification is clicked
-//        setStyleAndText(builder, subscription, notification) // Preview picture or big text style
         setClickAction(builder, subscription, notification)
         maybeSetDeleteIntent(builder, insistent)
         maybeSetSound(builder, insistent, update)
         maybeSetProgress(builder, notification)
         maybeAddOpenAction(builder, notification)
         maybeAddBrowseAction(builder, notification)
-//        maybeAddDownloadAction(builder, notification)
-//        maybeAddCancelAction(builder, notification)
+        if (repository.getAddAttachmentEnabled()) {
+            setStyleAndText(builder, subscription, notification) // Preview picture or big text style
+            maybeAddDownloadAction(builder, notification)
+            maybeAddCancelAction(builder, notification)
+        }
         maybeAddUserActions(builder, notification)
-
         maybeCreateNotificationGroup(groupId, subscriptionGroupName(subscription))
         maybeCreateNotificationChannel(groupId, notification.priority)
         maybePlayInsistentSound(groupId, insistent)
-
-//        val hasAttach = if (notification.attachment != null) true else false
-//        val attachReady = if ((hasAttach) && (notification.attachment?.progress == ATTACHMENT_PROGRESS_DONE)) true else false
-//        if (hasAttach and !attachReady) {
-//            return
-//        }
         notificationManager.notify(notification.notificationId, builder.build())
     }
 
@@ -178,8 +197,12 @@ class NotificationService(val context: Context) {
         } else {
             attachment.name
         }
-        if (attachment.progress in 0..99) {
-            return context.getString(R.string.notification_popup_file_downloading, attachmentInfos, attachment.progress, message)
+        if (attachment.progress != null && attachment.progress in 0..99) {
+            if (repository.getDownloadProgressEnabled()) {
+                return context.getString(R.string.notification_popup_file_downloading, attachmentInfos, attachment.progress, message)
+            } else {
+                return message // Just show the message while downloading
+            }
         }
         if (attachment.progress == ATTACHMENT_PROGRESS_DONE) {
             return context.getString(R.string.notification_popup_file_download_successful, message, attachmentInfos)
@@ -206,8 +229,8 @@ class NotificationService(val context: Context) {
 
     private fun maybeSetProgress(builder: NotificationCompat.Builder, notification: Notification) {
         val progress = notification.attachment?.progress
-        if (progress in 0..99) {
-            builder.setProgress(100, progress!!, false)
+        if (progress != null && progress in 0..99 && repository.getDownloadProgressEnabled()) {
+            builder.setProgress(100, progress, false)
         } else {
             builder.setProgress(0, 0, false) // Remove progress bar
         }

--- a/app/src/main/java/io/heckel/ntfy/msg/NotificationService.kt
+++ b/app/src/main/java/io/heckel/ntfy/msg/NotificationService.kt
@@ -38,7 +38,8 @@ class NotificationService(val context: Context) {
         val active = notificationManager.activeNotifications.find { it.id == notification.notificationId } != null
         if (active) {
             val progress = notification.attachment?.progress
-            if (progress != null && progress in 0..99 && !repository.getDownloadProgressEnabled()) {
+            val downloadProgress = if (subscription.downloadProgress == Repository.DOWNLOAD_PROGRESS_USE_GLOBAL) repository.getDownloadProgressEnabled() else subscription.downloadProgress == Repository.DOWNLOAD_PROGRESS_ON
+            if (progress != null && progress in 0..99 && !downloadProgress) {
                 return // Progress update, but disabled
             }
             Log.d(TAG, "Updating notification $notification")
@@ -46,7 +47,8 @@ class NotificationService(val context: Context) {
         } else {
             val progress = notification.attachment?.progress
             val finished = progress == ATTACHMENT_PROGRESS_DONE || progress == ATTACHMENT_PROGRESS_FAILED
-            if (finished && repository.getWaitForAttachmentEnabled() && shouldNotify(subscription, notification)) {
+            val waitForAttachment = if (subscription.waitForAttachment == Repository.WAIT_FOR_ATTACHMENT_USE_GLOBAL) repository.getWaitForAttachmentEnabled() else subscription.waitForAttachment == Repository.WAIT_FOR_ATTACHMENT_ON
+            if (finished && waitForAttachment && shouldNotify(subscription, notification)) {
                 Log.d(TAG, "Displaying deferred notification $notification")
                 displayInternal(subscription, notification)
             }
@@ -123,8 +125,9 @@ class NotificationService(val context: Context) {
         setClickAction(builder, subscription, notification)
         maybeSetDeleteIntent(builder, insistent)
         maybeSetSound(builder, insistent, update)
-        if (repository.getAddAttachmentEnabled()) {
-            maybeSetProgress(builder, notification)
+        val addAttachment = if (subscription.addAttachment == Repository.ADD_ATTACHMENT_USE_GLOBAL) repository.getAddAttachmentEnabled() else subscription.addAttachment == Repository.ADD_ATTACHMENT_ON
+        if (addAttachment) {
+            maybeSetProgress(builder, subscription, notification)
             maybeAddOpenAction(builder, notification)
             maybeAddBrowseAction(builder, notification)
             setStyleAndText(builder, subscription, notification) // Preview picture or big text style
@@ -175,13 +178,13 @@ class NotificationService(val context: Context) {
                         .bigPicture(attachmentBitmap)
                         .bigLargeIcon(largeIcon)) // May be null
             } catch (_: Exception) {
-                val message = maybeAppendActionErrors(formatMessageMaybeWithAttachmentInfos(notification), notification)
+                val message = maybeAppendActionErrors(formatMessageMaybeWithAttachmentInfos(subscription, notification), notification)
                 builder
                     .setContentText(message)
                     .setStyle(NotificationCompat.BigTextStyle().bigText(message))
             }
         } else {
-            val message = maybeAppendActionErrors(formatMessageMaybeWithAttachmentInfos(notification), notification)
+            val message = maybeAppendActionErrors(formatMessageMaybeWithAttachmentInfos(subscription, notification), notification)
             builder
                 .setContentText(message)
                 .setStyle(NotificationCompat.BigTextStyle().bigText(message))
@@ -189,7 +192,7 @@ class NotificationService(val context: Context) {
         }
     }
 
-    private fun formatMessageMaybeWithAttachmentInfos(notification: Notification): CharSequence {
+    private fun formatMessageMaybeWithAttachmentInfos(subscription: Subscription, notification: Notification): CharSequence {
         val message = maybeMarkdown(formatMessage(notification), notification)
         val attachment = notification.attachment ?: return message
         val attachmentInfos = if (attachment.size != null) {
@@ -198,7 +201,8 @@ class NotificationService(val context: Context) {
             attachment.name
         }
         if (attachment.progress != null && attachment.progress in 0..99) {
-            if (repository.getDownloadProgressEnabled()) {
+            val downloadProgress = if (subscription.downloadProgress == Repository.DOWNLOAD_PROGRESS_USE_GLOBAL) repository.getDownloadProgressEnabled() else subscription.downloadProgress == Repository.DOWNLOAD_PROGRESS_ON
+            if (downloadProgress) {
                 return context.getString(R.string.notification_popup_file_downloading, attachmentInfos, attachment.progress, message)
             } else {
                 return message // Just show the message while downloading
@@ -227,9 +231,10 @@ class NotificationService(val context: Context) {
         }
     }
 
-    private fun maybeSetProgress(builder: NotificationCompat.Builder, notification: Notification) {
+    private fun maybeSetProgress(builder: NotificationCompat.Builder, subscription: Subscription, notification: Notification) {
         val progress = notification.attachment?.progress
-        if (progress != null && progress in 0..99 && repository.getDownloadProgressEnabled()) {
+        val downloadProgress = if (subscription.downloadProgress == Repository.DOWNLOAD_PROGRESS_USE_GLOBAL) repository.getDownloadProgressEnabled() else subscription.downloadProgress == Repository.DOWNLOAD_PROGRESS_ON
+        if (progress != null && progress in 0..99 && downloadProgress) {
             builder.setProgress(100, progress, false)
         } else {
             builder.setProgress(0, 0, false) // Remove progress bar

--- a/app/src/main/java/io/heckel/ntfy/ui/DetailActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/DetailActivity.kt
@@ -232,6 +232,9 @@ class DetailActivity : AppCompatActivity(), NotificationFragment.NotificationSet
                     upAppId = null,
                     upConnectorToken = null,
                     displayName = displayName,
+                    addAttachment = Repository.ADD_ATTACHMENT_USE_GLOBAL,
+                    downloadProgress = Repository.DOWNLOAD_PROGRESS_USE_GLOBAL,
+                    waitForAttachment = Repository.WAIT_FOR_ATTACHMENT_USE_GLOBAL,
                     totalCount = 0,
                     newCount = 0,
                     lastActive = Date().time/1000
@@ -258,12 +261,12 @@ class DetailActivity : AppCompatActivity(), NotificationFragment.NotificationSet
             }
 
             // Add extras needed in loadView(); normally these are added in MainActivity
-            intent.putExtra(MainActivity.EXTRA_SUBSCRIPTION_ID, subscription.id)
-            intent.putExtra(MainActivity.EXTRA_SUBSCRIPTION_BASE_URL, subscription.baseUrl)
-            intent.putExtra(MainActivity.EXTRA_SUBSCRIPTION_TOPIC, subscription.topic)
-            intent.putExtra(MainActivity.EXTRA_SUBSCRIPTION_DISPLAY_NAME, displayName(appBaseUrl, subscription))
-            intent.putExtra(MainActivity.EXTRA_SUBSCRIPTION_INSTANT, subscription.instant)
-            intent.putExtra(MainActivity.EXTRA_SUBSCRIPTION_MUTED_UNTIL, subscription.mutedUntil)
+            intent.putExtra(MainActivity.EXTRA_SUBSCRIPTION_ID, subscription!!.id)
+            intent.putExtra(MainActivity.EXTRA_SUBSCRIPTION_BASE_URL, subscription!!.baseUrl)
+            intent.putExtra(MainActivity.EXTRA_SUBSCRIPTION_TOPIC, subscription!!.topic)
+            intent.putExtra(MainActivity.EXTRA_SUBSCRIPTION_DISPLAY_NAME, displayName(appBaseUrl, subscription!!))
+            intent.putExtra(MainActivity.EXTRA_SUBSCRIPTION_INSTANT, subscription!!.instant)
+            intent.putExtra(MainActivity.EXTRA_SUBSCRIPTION_MUTED_UNTIL, subscription!!.mutedUntil)
 
             runOnUiThread {
                 loadView()

--- a/app/src/main/java/io/heckel/ntfy/ui/DetailSettingsActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/DetailSettingsActivity.kt
@@ -140,6 +140,9 @@ class DetailSettingsActivity : AppCompatActivity() {
                 loadMinPriorityPref()
                 loadAutoDeletePref()
                 loadInsistentMaxPriorityPref()
+                loadAddAttachmentPref()
+                loadDownloadProgressPref()
+                loadWaitForAttachmentPref()
                 loadIconSetPref()
                 loadIconRemovePref()
                 loadDedicatedChannelsPrefs()
@@ -347,6 +350,87 @@ class DetailSettingsActivity : AppCompatActivity() {
                     getString(R.string.settings_notifications_insistent_max_priority_summary_enabled)
                 } else {
                     getString(R.string.settings_notifications_insistent_max_priority_summary_disabled)
+                }
+                maybeAppendGlobal(summary, global)
+            }
+        }
+
+        private fun loadAddAttachmentPref() {
+            val prefId = context?.getString(R.string.detail_settings_notifications_add_attachment_key) ?: return
+            val pref: ListPreference? = findPreference(prefId)
+            pref?.isVisible = true
+            pref?.value = subscription.addAttachment.toString()
+            pref?.preferenceDataStore = object : PreferenceDataStore() {
+                override fun putString(key: String?, value: String?) {
+                    val intValue = value?.toIntOrNull() ?:return
+                    save(subscription.copy(addAttachment = intValue))
+                }
+                override fun getString(key: String?, defValue: String?): String {
+                    return subscription.addAttachment.toString()
+                }
+            }
+            pref?.summaryProvider = Preference.SummaryProvider<ListPreference> { preference ->
+                val value = preference.value.toIntOrNull() ?: Repository.ADD_ATTACHMENT_USE_GLOBAL
+                val global = value == Repository.ADD_ATTACHMENT_USE_GLOBAL
+                val enabled = if (global) repository.getAddAttachmentEnabled() else value == Repository.ADD_ATTACHMENT_ON
+                val summary = if (enabled) {
+                    getString(R.string.settings_notifications_add_attachment_summary_enabled)
+                } else {
+                    getString(R.string.settings_notifications_add_attachment_summary_disabled)
+                }
+                maybeAppendGlobal(summary, global)
+            }
+        }
+
+        private fun loadDownloadProgressPref() {
+            val prefId = context?.getString(R.string.detail_settings_notifications_download_progress_key) ?: return
+            val pref: ListPreference? = findPreference(prefId)
+            pref?.isVisible = true
+            pref?.value = subscription.downloadProgress.toString()
+            pref?.preferenceDataStore = object : PreferenceDataStore() {
+                override fun putString(key: String?, value: String?) {
+                    val intValue = value?.toIntOrNull() ?:return
+                    save(subscription.copy(downloadProgress = intValue))
+                }
+                override fun getString(key: String?, defValue: String?): String {
+                    return subscription.downloadProgress.toString()
+                }
+            }
+            pref?.summaryProvider = Preference.SummaryProvider<ListPreference> { preference ->
+                val value = preference.value.toIntOrNull() ?: Repository.DOWNLOAD_PROGRESS_USE_GLOBAL
+                val global = value == Repository.DOWNLOAD_PROGRESS_USE_GLOBAL
+                val enabled = if (global) repository.getDownloadProgressEnabled() else value == Repository.DOWNLOAD_PROGRESS_ON
+                val summary = if (enabled) {
+                    getString(R.string.settings_notifications_download_progress_summary_enabled)
+                } else {
+                    getString(R.string.settings_notifications_download_progress_summary_disabled)
+                }
+                maybeAppendGlobal(summary, global)
+            }
+        }
+
+        private fun loadWaitForAttachmentPref() {
+            val prefId = context?.getString(R.string.detail_settings_notifications_wait_for_attachment_key) ?: return
+            val pref: ListPreference? = findPreference(prefId)
+            pref?.isVisible = true
+            pref?.value = subscription.waitForAttachment.toString()
+            pref?.preferenceDataStore = object : PreferenceDataStore() {
+                override fun putString(key: String?, value: String?) {
+                    val intValue = value?.toIntOrNull() ?:return
+                    save(subscription.copy(waitForAttachment = intValue))
+                }
+                override fun getString(key: String?, defValue: String?): String {
+                    return subscription.waitForAttachment.toString()
+                }
+            }
+            pref?.summaryProvider = Preference.SummaryProvider<ListPreference> { preference ->
+                val value = preference.value.toIntOrNull() ?: Repository.WAIT_FOR_ATTACHMENT_USE_GLOBAL
+                val global = value == Repository.WAIT_FOR_ATTACHMENT_USE_GLOBAL
+                val enabled = if (global) repository.getWaitForAttachmentEnabled() else value == Repository.WAIT_FOR_ATTACHMENT_ON
+                val summary = if (enabled) {
+                    getString(R.string.settings_notifications_wait_for_attachment_summary_enabled)
+                } else {
+                    getString(R.string.settings_notifications_wait_for_attachment_summary_disabled)
                 }
                 maybeAppendGlobal(summary, global)
             }

--- a/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/MainActivity.kt
@@ -717,6 +717,9 @@ class MainActivity : AppCompatActivity(), AddFragment.SubscribeListener, Notific
             upAppId = null,
             upConnectorToken = null,
             displayName = null,
+            addAttachment = Repository.ADD_ATTACHMENT_USE_GLOBAL,
+            downloadProgress = Repository.DOWNLOAD_PROGRESS_USE_GLOBAL,
+            waitForAttachment = Repository.WAIT_FOR_ATTACHMENT_USE_GLOBAL,
             totalCount = 0,
             newCount = 0,
             lastActive = Date().time/1000

--- a/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
+++ b/app/src/main/java/io/heckel/ntfy/ui/SettingsActivity.kt
@@ -257,6 +257,66 @@ class SettingsActivity : AppCompatActivity(), PreferenceFragmentCompat.OnPrefere
                 }
             }
 
+            // Add attachment
+            val addAttachmentPrefId = context?.getString(R.string.settings_notifications_add_attachment_key) ?: return
+            val addAttachment: SwitchPreferenceCompat? = findPreference(addAttachmentPrefId)
+            addAttachment?.isChecked = repository.getAddAttachmentEnabled()
+            addAttachment?.preferenceDataStore = object : PreferenceDataStore() {
+                override fun putBoolean(key: String?, value: Boolean) {
+                    repository.setAddAttachmentEnabled(value)
+                }
+                override fun getBoolean(key: String?, defValue: Boolean): Boolean {
+                    return repository.getAddAttachmentEnabled()
+                }
+            }
+            addAttachment?.summaryProvider = Preference.SummaryProvider<SwitchPreferenceCompat> { pref ->
+                if (pref.isChecked) {
+                    getString(R.string.settings_notifications_add_attachment_summary_enabled)
+                } else {
+                    getString(R.string.settings_notifications_add_attachment_summary_disabled)
+                }
+            }
+
+            // Download progress
+            val downloadProgressPrefId = context?.getString(R.string.settings_notifications_download_progress_key) ?: return
+            val downloadProgress: SwitchPreferenceCompat? = findPreference(downloadProgressPrefId)
+            downloadProgress?.isChecked = repository.getDownloadProgressEnabled()
+            downloadProgress?.preferenceDataStore = object : PreferenceDataStore() {
+                override fun putBoolean(key: String?, value: Boolean) {
+                    repository.setDownloadProgressEnabled(value)
+                }
+                override fun getBoolean(key: String?, defValue: Boolean): Boolean {
+                    return repository.getDownloadProgressEnabled()
+                }
+            }
+            downloadProgress?.summaryProvider = Preference.SummaryProvider<SwitchPreferenceCompat> { pref ->
+                if (pref.isChecked) {
+                    getString(R.string.settings_notifications_download_progress_summary_enabled)
+                } else {
+                    getString(R.string.settings_notifications_download_progress_summary_disabled)
+                }
+            }
+
+            // Wait for attachment
+            val waitForAttachmentPrefId = context?.getString(R.string.settings_notifications_wait_for_attachment_key) ?: return
+            val waitForAttachment: SwitchPreferenceCompat? = findPreference(waitForAttachmentPrefId)
+            waitForAttachment?.isChecked = repository.getWaitForAttachmentEnabled()
+            waitForAttachment?.preferenceDataStore = object : PreferenceDataStore() {
+                override fun putBoolean(key: String?, value: Boolean) {
+                    repository.setWaitForAttachmentEnabled(value)
+                }
+                override fun getBoolean(key: String?, defValue: Boolean): Boolean {
+                    return repository.getWaitForAttachmentEnabled()
+                }
+            }
+            waitForAttachment?.summaryProvider = Preference.SummaryProvider<SwitchPreferenceCompat> { pref ->
+                if (pref.isChecked) {
+                    getString(R.string.settings_notifications_wait_for_attachment_summary_enabled)
+                } else {
+                    getString(R.string.settings_notifications_wait_for_attachment_summary_disabled)
+                }
+            }
+
             // Channel settings
             val channelPrefsPrefId = context?.getString(R.string.settings_notifications_channel_prefs_key) ?: return
             val channelPrefs: Preference? = findPreference(channelPrefsPrefId)

--- a/app/src/main/java/io/heckel/ntfy/up/BroadcastReceiver.kt
+++ b/app/src/main/java/io/heckel/ntfy/up/BroadcastReceiver.kt
@@ -93,6 +93,9 @@ class BroadcastReceiver : android.content.BroadcastReceiver() {
                     upAppId = appId,
                     upConnectorToken = connectorToken,
                     displayName = null,
+                    addAttachment = Repository.ADD_ATTACHMENT_USE_GLOBAL,
+                    downloadProgress = Repository.DOWNLOAD_PROGRESS_USE_GLOBAL,
+                    waitForAttachment = Repository.WAIT_FOR_ATTACHMENT_USE_GLOBAL,
                     totalCount = 0,
                     newCount = 0,
                     lastActive = Date().time/1000

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -379,6 +379,15 @@
     <string name="settings_notifications_insistent_max_priority_title">Keep alerting for highest priority</string>
     <string name="settings_notifications_insistent_max_priority_summary_enabled">Max priority notifications continuously alert until dismissed</string>
     <string name="settings_notifications_insistent_max_priority_summary_disabled">Max priority notifications only alert once</string>
+    <string name="settings_notifications_add_attachment_title">Add attachment</string>
+    <string name="settings_notifications_add_attachment_summary_enabled">Attachments are added to the notification (e.g. as image preview)</string>
+    <string name="settings_notifications_add_attachment_summary_disabled">Attachments are not added to the notification</string>
+    <string name="settings_notifications_download_progress_title">Show download progress</string>
+    <string name="settings_notifications_download_progress_summary_enabled">Notification is updated with the attachment download progress</string>
+    <string name="settings_notifications_download_progress_summary_disabled">Notification is not updated with download progress</string>
+    <string name="settings_notifications_wait_for_attachment_title">Wait for attachment</string>
+    <string name="settings_notifications_wait_for_attachment_summary_enabled">Notification is only shown once the attachment is downloaded</string>
+    <string name="settings_notifications_wait_for_attachment_summary_disabled">Notification is shown immediately, even if attachment is still downloading</string>
     <string name="settings_general_header">General</string>
     <string name="settings_appearance_header">Appearance</string>
     <string name="settings_general_default_base_url_title">Default server</string>

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -48,6 +48,9 @@
     <string name="detail_settings_notifications_dedicated_channels_key" translatable="false">SubscriptionDedicatedChannels</string>
     <string name="detail_settings_notifications_open_channels_key" translatable="false">SubscriptionOpenChannels</string>
     <string name="detail_settings_notifications_min_priority_key" translatable="false">SubscriptionMinPriority</string>
+    <string name="detail_settings_notifications_add_attachment_key" translatable="false">SubscriptionAddAttachment</string>
+    <string name="detail_settings_notifications_download_progress_key" translatable="false">SubscriptionDownloadProgress</string>
+    <string name="detail_settings_notifications_wait_for_attachment_key" translatable="false">SubscriptionWaitForAttachment</string>
     <string name="detail_settings_notifications_auto_delete_key" translatable="false">SubscriptionAutoDelete</string>
     <string name="detail_settings_notifications_insistent_max_priority_key" translatable="false">SubscriptionInsistentMaxPriority</string>
     <string name="settings_advanced_connection_alert_key" translatable="false">ConnectionAlert</string>
@@ -168,6 +171,36 @@
     </string-array>
     <string-array name="detail_settings_notifications_insistent_max_priority_values">
         <item>-1</item> <!-- Same as Repository.INSISTENT_MAX_PRIORITY_USE_GLOBAL -->
+        <item>1</item>
+        <item>0</item>
+    </string-array>
+    <string-array name="detail_settings_notifications_add_attachment_entries">
+        <item>@string/detail_settings_global_setting_title</item>
+        <item>@string/settings_notifications_add_attachment_summary_enabled</item>
+        <item>@string/settings_notifications_add_attachment_summary_disabled</item>
+    </string-array>
+    <string-array name="detail_settings_notifications_add_attachment_values">
+        <item>-1</item> <!-- Same as Repository.ADD_ATTACHMENT_USE_GLOBAL -->
+        <item>1</item>
+        <item>0</item>
+    </string-array>
+    <string-array name="detail_settings_notifications_download_progress_entries">
+        <item>@string/detail_settings_global_setting_title</item>
+        <item>@string/settings_notifications_download_progress_summary_enabled</item>
+        <item>@string/settings_notifications_download_progress_summary_disabled</item>
+    </string-array>
+    <string-array name="detail_settings_notifications_download_progress_values">
+        <item>-1</item> <!-- Same as Repository.DOWNLOAD_PROGRESS_USE_GLOBAL -->
+        <item>1</item>
+        <item>0</item>
+    </string-array>
+    <string-array name="detail_settings_notifications_wait_for_attachment_entries">
+        <item>@string/detail_settings_global_setting_title</item>
+        <item>@string/settings_notifications_wait_for_attachment_summary_enabled</item>
+        <item>@string/settings_notifications_wait_for_attachment_summary_disabled</item>
+    </string-array>
+    <string-array name="detail_settings_notifications_wait_for_attachment_values">
+        <item>-1</item> <!-- Same as Repository.WAIT_FOR_ATTACHMENT_USE_GLOBAL -->
         <item>1</item>
         <item>0</item>
     </string-array>

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -18,6 +18,9 @@
     <string name="settings_notifications_channel_prefs_key" translatable="false">ChannelPrefs</string>
     <string name="settings_notifications_auto_download_key" translatable="false">AutoDownload</string>
     <string name="settings_notifications_auto_delete_key" translatable="false">AutoDelete</string>
+    <string name="settings_notifications_add_attachment_key" translatable="false">AddAttachment</string>
+    <string name="settings_notifications_download_progress_key" translatable="false">DownloadProgress</string>
+    <string name="settings_notifications_wait_for_attachment_key" translatable="false">WaitForAttachment</string>
     <string name="settings_notifications_insistent_max_priority_key" translatable="false">InsistentMaxPriority</string>
     <string name="settings_general_default_base_url_key" translatable="false">DefaultBaseURL</string>
     <string name="settings_general_users_key" translatable="false">ManageUsers</string>

--- a/app/src/main/res/xml/detail_preferences.xml
+++ b/app/src/main/res/xml/detail_preferences.xml
@@ -35,6 +35,27 @@
                 app:entryValues="@array/detail_settings_notifications_insistent_max_priority_values"
                 app:defaultValue="-1"
                 app:isPreferenceVisible="false"/> <!-- Same as Repository.INSISTENT_MAX_PRIORITY_USE_GLOBAL -->
+        <ListPreference
+                app:key="@string/detail_settings_notifications_add_attachment_key"
+                app:title="@string/settings_notifications_add_attachment_title"
+                app:entries="@array/detail_settings_notifications_add_attachment_entries"
+                app:entryValues="@array/detail_settings_notifications_add_attachment_values"
+                app:defaultValue="-1"
+                app:isPreferenceVisible="false"/> <!-- Same as Repository.ADD_ATTACHMENT_USE_GLOBAL -->
+        <ListPreference
+                app:key="@string/detail_settings_notifications_download_progress_key"
+                app:title="@string/settings_notifications_download_progress_title"
+                app:entries="@array/detail_settings_notifications_download_progress_entries"
+                app:entryValues="@array/detail_settings_notifications_download_progress_values"
+                app:defaultValue="-1"
+                app:isPreferenceVisible="false"/> <!-- Same as Repository.DOWNLOAD_PROGRESS_USE_GLOBAL -->
+        <ListPreference
+                app:key="@string/detail_settings_notifications_wait_for_attachment_key"
+                app:title="@string/settings_notifications_wait_for_attachment_title"
+                app:entries="@array/detail_settings_notifications_wait_for_attachment_entries"
+                app:entryValues="@array/detail_settings_notifications_wait_for_attachment_values"
+                app:defaultValue="-1"
+                app:isPreferenceVisible="false"/> <!-- Same as Repository.WAIT_FOR_ATTACHMENT_USE_GLOBAL -->
         <SwitchPreferenceCompat
                 app:key="@string/detail_settings_notifications_dedicated_channels_key"
                 app:title="@string/detail_settings_notifications_dedicated_channels_title"

--- a/app/src/main/res/xml/main_preferences.xml
+++ b/app/src/main/res/xml/main_preferences.xml
@@ -29,6 +29,24 @@
                 app:key="@string/settings_notifications_insistent_max_priority_key"
                 app:title="@string/settings_notifications_insistent_max_priority_title"
                 app:defaultValue="false"/>
+        <SwitchPreferenceCompat
+                app:key="@string/settings_notifications_add_attachment_key"
+                app:title="@string/settings_notifications_add_attachment_title"
+                app:summaryOn="@string/settings_notifications_add_attachment_summary_enabled"
+                app:summaryOff="@string/settings_notifications_add_attachment_summary_disabled"
+                app:defaultValue="true"/>
+        <SwitchPreferenceCompat
+                app:key="@string/settings_notifications_download_progress_key"
+                app:title="@string/settings_notifications_download_progress_title"
+                app:summaryOn="@string/settings_notifications_download_progress_summary_enabled"
+                app:summaryOff="@string/settings_notifications_download_progress_summary_disabled"
+                app:defaultValue="true"/>
+        <SwitchPreferenceCompat
+                app:key="@string/settings_notifications_wait_for_attachment_key"
+                app:title="@string/settings_notifications_wait_for_attachment_title"
+                app:summaryOn="@string/settings_notifications_wait_for_attachment_summary_enabled"
+                app:summaryOff="@string/settings_notifications_wait_for_attachment_summary_disabled"
+                app:defaultValue="false"/>
         <Preference
                 app:key="@string/settings_notifications_channel_prefs_key"
                 app:title="@string/settings_notifications_channel_prefs_title"


### PR DESCRIPTION
Here are a few features that make the app more useful for me.  I hope they're useful to others too.

My current use case to ntfy is for my driveway alarm.  When a car is detected, I send a notification that includes a photo of the driveway to show the vehicle.  I also use an amazfit watch that will show the notification.  The notification elements changes below follow my evolution of making my watch notification acceptable.

1.   Retry download.  
     A backoff timer based retry for downloading attachments.  10 exponential retries starting at 5 seconds
      Reason:  When I drive away, the attachment download failed as I drove out of WiFi range.  The only way to get the photo was the manual download button, as long as I remembered before the link expired.

2.  Configurable Notification elements.
    a.  Wait for attachment.
         With this disabled, the notification is not shown until the attachment is downloaded
         Reason:  My watch was showing the initial message, before the attachment was downloaded.   When the attachment is ready, the notification on the phone is updated, but the watch only vibrated without updating the notification to add the photo.  The result is I was buzzed twice, for every notification.   

   b.  Show download progress
         With this disabled, the notification is not updated to show download progress
		 Reason:  Same as above.  the update for progress was also vibrating my watch with no change visible
		 
   c.  Add Attachment
         With this disabled, the attachment is not included in the notification
		 Reason:  After getting the watch notifications minimized, I realized that the attached photo
		 was too small on the watch, so why include it.
		 
In my own use, I have all 3 disabled to work how I want.  I leave all 3 options to support others uses

The options are at the global settings level and at the subscription level for flexibility.